### PR TITLE
Add color prop for audio buttons

### DIFF
--- a/components/AudioButton.js
+++ b/components/AudioButton.js
@@ -6,13 +6,14 @@
 import { useState } from 'react'
 import { playAudio } from '../lib/audio-utils'
 
-export default function AudioButton({ 
-  wordId, 
-  italianText, 
+export default function AudioButton({
+  wordId,
+  italianText,
   audioFilename = null,
   size = 'md',
   className = '',
-  title = null
+  title = null,
+  colorClass = 'bg-emerald-600 hover:bg-emerald-700'
 }) {
   const [isPlaying, setIsPlaying] = useState(false)
   const [isError, setIsError] = useState(false)
@@ -66,13 +67,13 @@ export default function AudioButton({
       disabled={isPlaying}
       className={`
         ${sizeClasses[size]}
-        bg-emerald-600 hover:bg-emerald-700 
-        text-white rounded-full 
-        flex items-center justify-center 
-        transition-all duration-200 
+        text-white rounded-full
+        flex items-center justify-center
+        transition-all duration-200
         flex-shrink-0
         ${hasPremiumAudio ? 'premium-audio border-2 border-yellow-400 shadow-lg' : ''}
         ${isPlaying ? 'opacity-75 cursor-not-allowed' : 'hover:scale-105'}
+        ${colorClass}
         ${isError ? 'bg-red-500 hover:bg-red-600' : ''}
         ${className}
       `}

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -582,7 +582,7 @@ function ConjugationRow({
           italianText={audioText}
           audioFilename={form.audio_filename}
           size="lg"
-          className={`${colors.audio}`}
+          colorClass={colors.audio}
         />
         <button className="bg-emerald-600 text-white w-8 h-8 rounded flex items-center justify-center text-lg font-semibold hover:bg-emerald-700 transition-colors">
           +

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -415,6 +415,7 @@ const renderVerbFeatures = () => {
                 audioFilename={audioFilename}
                 size="md"
                 title={hasPremiumAudio ? `Play premium audio (${voiceName})` : 'Play pronunciation'}
+                colorClass="bg-emerald-600 hover:bg-emerald-700"
               />
               
               {renderTags(processedTags.essential, 'essential')}


### PR DESCRIPTION
## Summary
- allow passing custom colors to `AudioButton`
- update `WordCard` and `ConjugationModal` to use new prop

## Testing
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68752b07f12483298ad5a8907fca1880