### PR TITLE
Refine conjugation row layout

### DIFF
--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -558,25 +558,25 @@ function ConjugationRow({
   const colors = getColors()
 
   return (
-    <div className="flex flex-col sm:flex-row items-start sm:items-center py-2 px-3 rounded-md hover:bg-gray-50 even:bg-gray-50 even:hover:bg-gray-100 transition-colors">
+    <div className="flex flex-wrap items-start sm:items-center py-2 px-3 rounded-md hover:bg-gray-50 even:bg-gray-50 even:hover:bg-gray-100 transition-colors">
       {/* Pronoun */}
-      <div className="min-w-[4rem] font-bold text-gray-600 text-lg">
+      <div className="min-w-[4rem] font-bold text-gray-600 text-lg mr-2">
         {pronounDisplay}
       </div>
 
       {/* Form */}
-      <div className={`min-w-[7rem] font-bold text-lg ${colors.form} flex items-center gap-1`}>
+      <div className={`min-w-[7rem] font-bold text-lg ${colors.form} flex items-center gap-1 mr-2`}>
         {form.form_text}
         {isIrregular && <span className="text-amber-500 text-base">⚠️</span>}
       </div>
 
       {/* Translation */}
-      <div className="w-full sm:flex-1 text-gray-600 text-lg mt-1 sm:mt-0 sm:mx-4">
+      <div className="basis-full sm:basis-auto sm:flex-1 text-gray-600 text-lg mt-1 sm:mt-0 sm:mx-4">
         {form.translation}
       </div>
 
       {/* Actions */}
-      <div className="flex gap-2 mt-2 sm:mt-0 self-end sm:self-auto">
+      <div className="flex gap-2 mt-2 sm:mt-0 self-end sm:self-auto ml-auto">
         <AudioButton
           wordId={form.id}
           italianText={audioText}

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -558,25 +558,25 @@ function ConjugationRow({
   const colors = getColors()
 
   return (
-    <div className="flex items-center py-2 px-3 rounded-md hover:bg-gray-50 even:bg-gray-50 even:hover:bg-gray-100 transition-colors min-h-12">
+    <div className="flex flex-col sm:flex-row items-start sm:items-center py-2 px-3 rounded-md hover:bg-gray-50 even:bg-gray-50 even:hover:bg-gray-100 transition-colors">
       {/* Pronoun */}
-      <div className="w-16 flex-shrink-0 font-bold text-gray-600 text-lg">
+      <div className="min-w-[4rem] font-bold text-gray-600 text-lg">
         {pronounDisplay}
       </div>
-      
+
       {/* Form */}
-      <div className={`w-32 flex-shrink-0 font-bold text-lg ${colors.form} flex items-center gap-1`}>
+      <div className={`min-w-[7rem] font-bold text-lg ${colors.form} flex items-center gap-1`}>
         {form.form_text}
         {isIrregular && <span className="text-amber-500 text-base">⚠️</span>}
       </div>
 
       {/* Translation */}
-      <div className="flex-1 text-gray-600 text-lg mr-4 ml-4">
+      <div className="w-full sm:flex-1 text-gray-600 text-lg mt-1 sm:mt-0 sm:mx-4">
         {form.translation}
       </div>
-      
+
       {/* Actions */}
-      <div className="flex items-center gap-2 flex-shrink-0">
+      <div className="flex gap-2 mt-2 sm:mt-0 self-end sm:self-auto">
         <AudioButton
           wordId={form.id}
           italianText={audioText}


### PR DESCRIPTION
## Summary
- refine the layout of conjugation rows for better responsive behavior
- place action buttons below translation on small screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68752e42f98c8329ba1a024f69fd168b