### PR TITLE
Implement gender variant calculation engine

### DIFF
--- a/components/AudioButton.js
+++ b/components/AudioButton.js
@@ -45,16 +45,13 @@ export default function AudioButton({
     } catch (error) {
       console.error('Audio playback failed:', error)
       setIsError(true)
-      
+
       // Show error state briefly, then reset
       setTimeout(() => {
         setIsError(false)
       }, 2000)
     } finally {
-      // Reset playing state after a delay
-      setTimeout(() => {
-        setIsPlaying(false)
-      }, 1000)
+      setIsPlaying(false)
     }
   }
 

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -639,30 +639,73 @@ function ConjugationRow({
   
   // Determine colors based on gender variants and toggle state
   const getColors = () => {
-    // Check if this is a form that actually changes based on gender
-    const hasActualGenderVariants =
+    // Check if this form has actual gender variants in the verb form
+    const hasVerbGenderVariants =
       form.tags?.includes('compound') &&
       (wordTags?.includes('essere-auxiliary') || form.base_form_id)
 
-    if (audioPreference === 'form-only' && !hasActualGenderVariants) {
-      // Form-only with no gender variants - default color
+    // Check if this is a 3rd person form that changes pronouns
+    const isThirdPerson =
+      form.tags?.includes('lui') ||
+      form.tags?.includes('lei') ||
+      extractTagValue(form.tags, 'pronoun') === 'lui' ||
+      extractTagValue(form.tags, 'pronoun') === 'lei'
+
+    if (audioPreference === 'form-only') {
+      if (hasVerbGenderVariants) {
+        // Form-only + compound: verb form changes, use gender colors
+        return {
+          form:
+            selectedGender === 'male'
+              ? isPlural
+                ? 'text-amber-500'
+                : 'text-blue-500'
+              : 'text-pink-500',
+          audio:
+            selectedGender === 'male'
+              ? isPlural
+                ? 'bg-amber-500'
+                : 'bg-blue-500'
+              : 'bg-pink-500'
+        }
+      }
+
+      // Form-only + simple: no changes, default color
       return {
         form: 'text-teal-600',
         audio: 'bg-emerald-600'
       }
-    }
-
-    // Either has gender variants or with-pronoun mode - use gender colors
-    if (selectedGender === 'male') {
-      return {
-        form: isPlural ? 'text-amber-500' : 'text-blue-500',
-        audio: isPlural ? 'bg-amber-500' : 'bg-blue-500'
+    } else {
+      // With-pronoun mode
+      if (hasVerbGenderVariants) {
+        // Compound: both pronoun and verb change
+        return {
+          form:
+            selectedGender === 'male'
+              ? isPlural
+                ? 'text-amber-500'
+                : 'text-blue-500'
+              : 'text-pink-500',
+          audio:
+            selectedGender === 'male'
+              ? isPlural
+                ? 'bg-amber-500'
+                : 'bg-blue-500'
+              : 'bg-pink-500'
+        }
+      } else if (isThirdPerson) {
+        // Simple + 3rd person: only pronoun changes
+        return {
+          form: selectedGender === 'male' ? 'text-blue-500' : 'text-pink-500',
+          audio: selectedGender === 'male' ? 'bg-blue-500' : 'bg-pink-500'
+        }
       }
-    }
 
-    return {
-      form: 'text-pink-500',
-      audio: 'bg-pink-500'
+      // Simple + 1st/2nd person: no changes
+      return {
+        form: 'text-teal-600',
+        audio: 'bg-emerald-600'
+      }
     }
   }
 

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -638,7 +638,13 @@ function ConjugationRow({
   const isPlural = form.tags?.includes('plurale') || ['noi', 'voi', 'loro'].includes(pronounDisplay)
   
   // Determine colors based on gender variants and toggle state
+  // Determine colors based on gender variants and toggle state
   const getColors = () => {
+    // Extract pronoun directly from tags (without helper)
+    const pronoun = form.tags?.find(tag =>
+      ['io', 'tu', 'lui', 'lei', 'noi', 'voi', 'loro'].includes(tag)
+    )
+
     // Check if this form has actual gender variants in the verb form
     const hasVerbGenderVariants =
       form.tags?.includes('compound') &&
@@ -648,8 +654,8 @@ function ConjugationRow({
     const isThirdPerson =
       form.tags?.includes('lui') ||
       form.tags?.includes('lei') ||
-      extractTagValue(form.tags, 'pronoun') === 'lui' ||
-      extractTagValue(form.tags, 'pronoun') === 'lei'
+      pronoun === 'lui' ||
+      pronoun === 'lei'
 
     if (audioPreference === 'form-only') {
       if (hasVerbGenderVariants) {

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -21,6 +21,7 @@ export default function ConjugationModal({
   const [isLoading, setIsLoading] = useState(false)
   const [audioPreference, setAudioPreference] = useState(userAudioPreference)
   const [selectedGender, setSelectedGender] = useState('male')
+  const [selectedFormality, setSelectedFormality] = useState('informal')
   const [dropdownOpen, setDropdownOpen] = useState(false)
 
   // Extract tag values from tag array
@@ -483,7 +484,7 @@ const loadConjugations = async () => {
               </div>
             </div>
 
-            {/* Right: Audio Controls */}
+            {/* Audio and Formality Controls */}
             <div className="w-48 flex flex-col gap-3">
               <div>
                 <label className="block text-xs font-semibold text-gray-700 mb-1">
@@ -492,13 +493,60 @@ const loadConjugations = async () => {
                 <button
                   onClick={toggleAudioPreference}
                   className={`w-full p-2 border border-gray-300 rounded-md text-sm font-medium transition-colors ${
-                    audioPreference === 'form-only' 
-                      ? 'bg-teal-600 text-white' 
+                    audioPreference === 'form-only'
+                      ? 'bg-teal-600 text-white'
                       : 'bg-teal-600 text-white'
                   }`}
                 >
                   {audioPreference === 'form-only' ? '📝 Form Only' : '👤 With Pronoun'}
                 </button>
+              </div>
+
+              {/* Formality Controls - Always visible */}
+              <div>
+                <label className="block text-xs font-semibold text-gray-700 mb-1">
+                  Formality
+                </label>
+                <div className="flex gap-2 justify-center">
+                  <button
+                    onClick={() => setSelectedFormality('informal')}
+                    className={`w-10 h-10 border-2 rounded-lg flex items-center justify-center text-lg transition-colors ${
+                      selectedFormality === 'informal'
+                        ? 'border-green-500 bg-green-500 text-white'
+                        : 'border-green-500 text-green-500 bg-white hover:bg-green-50'
+                    }`}
+                    title="Informal (tu/voi)"
+                  >
+                    😊
+                  </button>
+                  <button
+                    onClick={() => setSelectedFormality('formal')}
+                    className={`w-10 h-10 border-2 rounded-lg flex items-center justify-center transition-colors ${
+                      selectedFormality === 'formal'
+                        ? 'border-purple-500 bg-purple-500 text-white'
+                        : 'border-purple-500 text-purple-500 bg-white hover:bg-purple-50'
+                    }`}
+                    title="Formal (Lei/Loro)"
+                  >
+                    <svg
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                      className="drop-shadow-sm"
+                    >
+                      {/* Royal Crown SVG */}
+                      <path d="M12 6L9 12H15L12 6Z" />
+                      <path d="M5 9L2 12H6L5 9Z" />
+                      <path d="M19 9L22 12H18L19 9Z" />
+                      <path d="M7 15L17 15L16 13H8L7 15Z" />
+                      <circle cx="12" cy="4" r="1.5" />
+                      <circle cx="5" cy="7" r="1" />
+                      <circle cx="19" cy="7" r="1" />
+                      <rect x="2" y="18" width="20" height="3" rx="1" />
+                    </svg>
+                  </button>
+                </div>
               </div>
 
               {/* Gender Controls - Only for ESSERE verbs */}

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -243,14 +243,17 @@ const loadConjugations = async () => {
     return pronoun || ''
   }
 
-  // Get translation based on audio preference, gender toggle, AND formality - WITH FORMAL SUPPORT
-  const getDynamicTranslation = (form) => {
-    const pronoun = extractTagValue(form.tags, 'pronoun')
+  // Get translation based on audio preference, gender toggle, AND formality - FIXED FORMAL DETECTION
+  const getDynamicTranslation = (displayForm, originalForm) => {
+    const originalPronoun = extractTagValue(originalForm.tags, 'pronoun')
+    const isFormalContext =
+      selectedFormality === 'formal' &&
+      (originalPronoun === 'tu' || originalPronoun === 'voi')
 
-    // Handle formal contexts first
-    if (selectedFormality === 'formal') {
-      if (pronoun === 'tu') {
-        let translation = form.translation
+    if (isFormalContext) {
+      let translation = displayForm.translation
+
+      if (originalPronoun === 'tu') {
         return translation
           .replace(/\bhe\/she\b/gi, 'you')
           .replace(/\bHe\/she\b/g, 'You')
@@ -260,28 +263,25 @@ const loadConjugations = async () => {
           .replace(/\bShe\b/g, 'You')
       }
 
-      if (pronoun === 'voi') {
-        let translation = form.translation
+      if (originalPronoun === 'voi') {
         return translation
           .replace(/\bthey\b/gi, 'you all')
           .replace(/\bThey\b/g, 'You all')
       }
     }
 
-    // Only modify translations for 3rd person in non-formal contexts
+    const pronoun = extractTagValue(displayForm.tags, 'pronoun')
+
     if (pronoun !== 'lui' && pronoun !== 'lei') {
-      return form.translation
+      return displayForm.translation
     }
 
-    // Get the original translation
-    let translation = form.translation
+    let translation = displayForm.translation
     const startsWithCapital = /^[A-Z]/.test(translation.trim())
 
-    // Check if this form has gender variants (compound tenses with ESSERE)
     const hasGenderVariants =
-      word?.tags?.includes('essere-auxiliary') && form.tags?.includes('compound')
+      word?.tags?.includes('essere-auxiliary') && displayForm.tags?.includes('compound')
 
-    // Determine final pronoun
     let targetPronoun
     if (audioPreference === 'form-only' && !hasGenderVariants) {
       targetPronoun = 'he/she'
@@ -289,7 +289,6 @@ const loadConjugations = async () => {
       targetPronoun = selectedGender === 'male' ? 'he' : 'she'
     }
 
-    // Placeholder approach to avoid cascading replacements
     translation = translation
       .replace(/\bhe\/she\b/gi, 'PLACEHOLDER')
       .replace(/\bHe\/she\b/g, 'PLACEHOLDER')
@@ -686,7 +685,7 @@ const loadConjugations = async () => {
                       return (
                         <ConjugationRow
                           key={form.id}
-                          form={{ ...displayForm, translation: getDynamicTranslation(displayForm) }}
+                          form={{ ...displayForm, translation: getDynamicTranslation(displayForm, form) }}
                           audioText={getAudioText(form)}
                           pronounDisplay={getPronounDisplay(form)}
                           isCompound={compound}
@@ -709,7 +708,7 @@ const loadConjugations = async () => {
                       return (
                         <ConjugationRow
                           key={form.id}
-                          form={{ ...displayForm, translation: getDynamicTranslation(displayForm) }}
+                          form={{ ...displayForm, translation: getDynamicTranslation(displayForm, form) }}
                           audioText={getAudioText(form)}
                           pronounDisplay={getPronounDisplay(form)}
                           isCompound={compound}
@@ -732,7 +731,7 @@ const loadConjugations = async () => {
                       return (
                         <ConjugationRow
                           key={form.id}
-                          form={{ ...displayForm, translation: getDynamicTranslation(displayForm) }}
+                          form={{ ...displayForm, translation: getDynamicTranslation(displayForm, form) }}
                           audioText={getAudioText(form)}
                           pronounDisplay={getPronounDisplay(form)}
                           isCompound={compound}

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -236,7 +236,7 @@ const loadConjugations = async () => {
     return pronoun || ''
   }
 
-  // Get translation based on audio preference and gender toggle - FIXED
+  // Get translation based on audio preference and gender toggle - BULLETPROOF VERSION
   const getDynamicTranslation = (form) => {
     const pronoun = extractTagValue(form.tags, 'pronoun')
 
@@ -245,48 +245,37 @@ const loadConjugations = async () => {
       return form.translation
     }
 
-    // Start from the original translation each time
+    // Get the original translation
     let translation = form.translation
 
     // Check if this form has gender variants (compound tenses with ESSERE)
     const hasGenderVariants =
       word?.tags?.includes('essere-auxiliary') && form.tags?.includes('compound')
 
+    // Determine final pronoun
+    let targetPronoun
     if (audioPreference === 'form-only' && !hasGenderVariants) {
-      // Form-only + simple ESSERE verbs: show "he/she"
-      if (
-        translation.toLowerCase().includes('he ') ||
-        translation.toLowerCase().startsWith('he ')
-      ) {
-        translation = translation
-          .replace(/\bhe\b/gi, 'he/she')
-          .replace(/^He\b/, 'He/she')
-      } else if (
-        translation.toLowerCase().includes('she ') ||
-        translation.toLowerCase().startsWith('she ')
-      ) {
-        translation = translation
-          .replace(/\bshe\b/gi, 'he/she')
-          .replace(/^She\b/, 'He/she')
-      }
-    } else if (hasGenderVariants || audioPreference === 'with-pronoun') {
-      // Compound tenses OR with-pronoun mode: show selected gender only
-      if (selectedGender === 'male') {
-        // Show "he" - replace any existing "she" or "he/she" 
-        translation = translation
-          .replace(/\bhe\/she\b/gi, 'he')
-          .replace(/^He\/she\b/, 'He')
-          .replace(/\bshe\b/gi, 'he')
-          .replace(/^She\b/, 'He')
-      } else {
-        // Show "she" - replace any existing "he" or "he/she"
-        translation = translation
-          .replace(/\bhe\/she\b/gi, 'she')
-          .replace(/^He\/she\b/, 'She')
-          .replace(/\bhe\b/gi, 'she')
-          .replace(/^He\b/, 'She')
-      }
+      targetPronoun = 'he/she'
+    } else {
+      targetPronoun = selectedGender === 'male' ? 'he' : 'she'
     }
+
+    // Placeholder approach to avoid cascading replacements
+    translation = translation
+      .replace(/\bhe\/she\b/gi, 'PLACEHOLDER')
+      .replace(/\bHe\/she\b/g, 'PLACEHOLDER')
+      .replace(/\bshe\/he\b/gi, 'PLACEHOLDER')
+      .replace(/\bShe\/he\b/g, 'PLACEHOLDER')
+      .replace(/\bhe\b/gi, 'PLACEHOLDER')
+      .replace(/\bshe\b/gi, 'PLACEHOLDER')
+      .replace(/\bHe\b/g, 'PLACEHOLDER')
+      .replace(/\bShe\b/g, 'PLACEHOLDER')
+
+    const finalPronoun = translation.startsWith('PLACEHOLDER')
+      ? targetPronoun.charAt(0).toUpperCase() + targetPronoun.slice(1)
+      : targetPronoun
+
+    translation = translation.replace(/PLACEHOLDER/g, finalPronoun)
 
     return translation
   }

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -160,8 +160,11 @@ const loadConjugations = async () => {
   }
 
   // Get current forms to display
+  // Get current forms to display
   const getCurrentForms = () => {
-    return conjugations[selectedMood]?.[selectedTense] || []
+    const currentForms = conjugations[selectedMood]?.[selectedTense] || []
+    console.log('🔍 Current forms for', selectedMood, selectedTense, ':', currentForms.length, 'forms')
+    return currentForms
   }
 
   // Order forms by pronoun sequence
@@ -235,27 +238,39 @@ const loadConjugations = async () => {
 
   // Group forms into singular/plural
   const groupFormsBySingularPlural = (forms) => {
+    console.log('🔍 Grouping forms:', forms.length, 'total forms')
+
     const orderedForms = orderFormsByPronoun(forms)
-    
-    const singular = orderedForms.filter(form => 
-      form.tags?.includes('singolare') || 
-      extractTagValue(form.tags, 'pronoun') === 'io' ||
-      extractTagValue(form.tags, 'pronoun') === 'tu' ||
-      extractTagValue(form.tags, 'pronoun') === 'lui' ||
-      extractTagValue(form.tags, 'pronoun') === 'lei'
-    )
-    
-    const plural = orderedForms.filter(form => 
-      form.tags?.includes('plurale') ||
-      extractTagValue(form.tags, 'pronoun') === 'noi' ||
-      extractTagValue(form.tags, 'pronoun') === 'voi' ||
-      extractTagValue(form.tags, 'pronoun') === 'loro'
-    )
-    
-    const other = orderedForms.filter(form => 
+
+    const singular = orderedForms.filter(form => {
+      const isPersonalSingular = form.tags?.includes('singolare') ||
+        extractTagValue(form.tags, 'pronoun') === 'io' ||
+        extractTagValue(form.tags, 'pronoun') === 'tu' ||
+        extractTagValue(form.tags, 'pronoun') === 'lui' ||
+        extractTagValue(form.tags, 'pronoun') === 'lei'
+
+      const isCalculatedSingular = form.variant_type === 'fem-sing'
+
+      return isPersonalSingular || isCalculatedSingular
+    })
+
+    const plural = orderedForms.filter(form => {
+      const isPersonalPlural = form.tags?.includes('plurale') ||
+        extractTagValue(form.tags, 'pronoun') === 'noi' ||
+        extractTagValue(form.tags, 'pronoun') === 'voi' ||
+        extractTagValue(form.tags, 'pronoun') === 'loro'
+
+      const isCalculatedPlural = form.variant_type === 'fem-plur'
+
+      return isPersonalPlural || isCalculatedPlural
+    })
+
+    const other = orderedForms.filter(form =>
       !singular.includes(form) && !plural.includes(form)
     )
-    
+
+    console.log('🔍 Grouped:', singular.length, 'singular,', plural.length, 'plural,', other.length, 'other')
+
     return { singular, plural, other }
   }
 

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -503,20 +503,26 @@ const loadConjugations = async () => {
                   <div className="flex gap-2 justify-center">
                     <button
                       onClick={() => setSelectedGender('male')}
+                      disabled={!currentForms.some(form => form.tags?.includes('compound'))}
                       className={`w-10 h-10 border-2 rounded-lg flex items-center justify-center text-lg transition-colors ${
-                        selectedGender === 'male'
-                          ? 'border-blue-500 bg-blue-500 text-white'
-                          : 'border-blue-500 text-blue-500 bg-white'
+                        !currentForms.some(form => form.tags?.includes('compound'))
+                          ? 'border-gray-300 text-gray-300 bg-gray-100 cursor-not-allowed'
+                          : selectedGender === 'male'
+                              ? 'border-blue-500 bg-blue-500 text-white'
+                              : 'border-blue-500 text-blue-500 bg-white hover:bg-blue-50'
                       }`}
                     >
                       ♂
                     </button>
                     <button
                       onClick={() => setSelectedGender('female')}
+                      disabled={!currentForms.some(form => form.tags?.includes('compound'))}
                       className={`w-10 h-10 border-2 rounded-lg flex items-center justify-center text-lg transition-colors ${
-                        selectedGender === 'female'
-                          ? 'border-pink-500 bg-pink-500 text-white'
-                          : 'border-pink-500 text-pink-500 bg-white'
+                        !currentForms.some(form => form.tags?.includes('compound'))
+                          ? 'border-gray-300 text-gray-300 bg-gray-100 cursor-not-allowed'
+                          : selectedGender === 'female'
+                              ? 'border-pink-500 bg-pink-500 text-white'
+                              : 'border-pink-500 text-pink-500 bg-white hover:bg-pink-50'
                       }`}
                     >
                       ♀
@@ -551,6 +557,7 @@ const loadConjugations = async () => {
                           isCompound={compound}
                           selectedGender={selectedGender}
                           audioPreference={audioPreference}
+                          wordTags={word?.tags || []}
                         />
                       )
                     })}
@@ -572,6 +579,7 @@ const loadConjugations = async () => {
                           isCompound={compound}
                           selectedGender={selectedGender}
                           audioPreference={audioPreference}
+                          wordTags={word?.tags || []}
                         />
                       )
                     })}
@@ -587,11 +595,12 @@ const loadConjugations = async () => {
                         key={form.id}
                         form={form}
                         audioText={getAudioText(form)}
-                        pronounDisplay={''}
-                        isCompound={compound}
-                        selectedGender={selectedGender}
-                        audioPreference={audioPreference}
-                      />
+                      pronounDisplay={''}
+                      isCompound={compound}
+                      selectedGender={selectedGender}
+                      audioPreference={audioPreference}
+                      wordTags={word?.tags || []}
+                    />
                     ))}
                   </>
                 )}
@@ -614,48 +623,44 @@ const loadConjugations = async () => {
 }
 
 // Individual conjugation row component
-function ConjugationRow({ 
-  form, 
-  audioText, 
-  pronounDisplay, 
-  isCompound, 
-  selectedGender, 
-  audioPreference 
+function ConjugationRow({
+  form,
+  audioText,
+  pronounDisplay,
+  isCompound,
+  selectedGender,
+  audioPreference,
+  wordTags
 }) {
   const isIrregular = form.tags?.includes('irregular')
   const isPlural = form.tags?.includes('plurale') || ['noi', 'voi', 'loro'].includes(pronounDisplay)
   
-  // Determine colors based on compound + gender
+  // Determine colors based on gender variants and toggle state
   const getColors = () => {
-    if (audioPreference === 'form-only') {
+    // Check if this form has gender variants (can change based on gender toggle)
+    const hasGenderVariants =
+      form.tags?.includes('compound') &&
+      (wordTags.includes('essere-auxiliary') || form.base_form_id)
+
+    if (!hasGenderVariants) {
+      // No gender variants - always use default color
       return {
         form: 'text-teal-600',
         audio: 'bg-emerald-600'
       }
     }
-    
-    if (isCompound) {
-      if (selectedGender === 'male') {
-        return {
-          form: isPlural ? 'text-amber-500' : 'text-blue-500',
-          audio: isPlural ? 'bg-amber-500' : 'bg-blue-500'
-        }
-      } else {
-        return {
-          form: 'text-pink-500',
-          audio: 'bg-pink-500'
-        }
-      }
-    } else if (['lui', 'lei'].includes(pronounDisplay.split('/')[0])) {
+
+    // Has gender variants - color based on current display
+    if (selectedGender === 'male') {
       return {
-        form: selectedGender === 'male' ? 'text-blue-500' : 'text-pink-500',
-        audio: selectedGender === 'male' ? 'bg-blue-500' : 'bg-pink-500'
+        form: isPlural ? 'text-amber-500' : 'text-blue-500',
+        audio: isPlural ? 'bg-amber-500' : 'bg-blue-500'
       }
-    }
-    
-    return {
-      form: 'text-teal-600',
-      audio: 'bg-emerald-600'
+    } else {
+      return {
+        form: 'text-pink-500',
+        audio: 'bg-pink-500'
+      }
     }
   }
 

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -243,11 +243,32 @@ const loadConjugations = async () => {
     return pronoun || ''
   }
 
-  // Get translation based on audio preference and gender toggle - BULLETPROOF VERSION
+  // Get translation based on audio preference, gender toggle, AND formality - WITH FORMAL SUPPORT
   const getDynamicTranslation = (form) => {
     const pronoun = extractTagValue(form.tags, 'pronoun')
 
-    // Only modify translations for 3rd person
+    // Handle formal contexts first
+    if (selectedFormality === 'formal') {
+      if (pronoun === 'tu') {
+        let translation = form.translation
+        return translation
+          .replace(/\bhe\/she\b/gi, 'you')
+          .replace(/\bHe\/she\b/g, 'You')
+          .replace(/\bhe\b/gi, 'you')
+          .replace(/\bshe\b/gi, 'you')
+          .replace(/\bHe\b/g, 'You')
+          .replace(/\bShe\b/g, 'You')
+      }
+
+      if (pronoun === 'voi') {
+        let translation = form.translation
+        return translation
+          .replace(/\bthey\b/gi, 'you all')
+          .replace(/\bThey\b/g, 'You all')
+      }
+    }
+
+    // Only modify translations for 3rd person in non-formal contexts
     if (pronoun !== 'lui' && pronoun !== 'lei') {
       return form.translation
     }

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -502,48 +502,64 @@ const loadConjugations = async () => {
                 </button>
               </div>
 
-              {/* Formality Controls - Always visible */}
+              {/* Formality Controls - Single Toggle */}
               <div>
                 <label className="block text-xs font-semibold text-gray-700 mb-1">
                   Formality
                 </label>
-                <div className="flex gap-2 justify-center">
+                <div className="flex justify-center">
                   <button
-                    onClick={() => setSelectedFormality('informal')}
-                    className={`w-10 h-10 border-2 rounded-lg flex items-center justify-center text-lg transition-colors ${
-                      selectedFormality === 'informal'
-                        ? 'border-green-500 bg-green-500 text-white'
-                        : 'border-green-500 text-green-500 bg-white hover:bg-green-50'
-                    }`}
-                    title="Informal (tu/voi)"
-                  >
-                    😊
-                  </button>
-                  <button
-                    onClick={() => setSelectedFormality('formal')}
-                    className={`w-10 h-10 border-2 rounded-lg flex items-center justify-center transition-colors ${
+                    onClick={() =>
+                      setSelectedFormality(
+                        selectedFormality === 'formal' ? 'informal' : 'formal'
+                      )
+                    }
+                    className={`w-12 h-10 border-2 rounded-lg flex items-center justify-center transition-colors ${
                       selectedFormality === 'formal'
-                        ? 'border-purple-500 bg-purple-500 text-white'
-                        : 'border-purple-500 text-purple-500 bg-white hover:bg-purple-50'
+                        ? 'border-purple-500 bg-purple-500 text-white shadow-md'
+                        : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
                     }`}
-                    title="Formal (Lei/Loro)"
+                    title={
+                      selectedFormality === 'formal'
+                        ? 'Formal (Lei/Loro)'
+                        : 'Informal (tu/voi) - Click for formal'
+                    }
                   >
                     <svg
-                      width="20"
-                      height="20"
+                      width="22"
+                      height="22"
                       viewBox="0 0 24 24"
                       fill="currentColor"
                       className="drop-shadow-sm"
                     >
-                      {/* Royal Crown SVG */}
-                      <path d="M12 6L9 12H15L12 6Z" />
-                      <path d="M5 9L2 12H6L5 9Z" />
-                      <path d="M19 9L22 12H18L19 9Z" />
-                      <path d="M7 15L17 15L16 13H8L7 15Z" />
-                      <circle cx="12" cy="4" r="1.5" />
-                      <circle cx="5" cy="7" r="1" />
-                      <circle cx="19" cy="7" r="1" />
-                      <rect x="2" y="18" width="20" height="3" rx="1" />
+                      {/* British Royal Crown SVG */}
+                      {/* Crown base band */}
+                      <ellipse cx="12" cy="19" rx="10" ry="2" />
+
+                      {/* Main crown body */}
+                      <path d="M3 17h18l-1-8H4l-1 8z" />
+
+                      {/* Crown points/peaks */}
+                      <path d="M6 9l1-3 2 2 3-4 3 4 2-2 1 3" />
+
+                      {/* Center arch */}
+                      <path d="M8 9c0-2 1.5-3 4-3s4 1 4 3" strokeWidth="0.5" stroke="currentColor" fill="none" />
+
+                      {/* Side arches */}
+                      <path d="M4 12c2-1 4-1 6 0" strokeWidth="0.5" stroke="currentColor" fill="none" />
+                      <path d="M14 12c2-1 4-1 6 0" strokeWidth="0.5" stroke="currentColor" fill="none" />
+
+                      {/* Crown jewels */}
+                      <circle cx="12" cy="8" r="1" opacity="0.8" />
+                      <circle cx="7" cy="10" r="0.5" opacity="0.6" />
+                      <circle cx="17" cy="10" r="0.5" opacity="0.6" />
+
+                      {/* Cross on top */}
+                      <path d="M11.5 5h1v3h-1z" />
+                      <path d="M10.5 6h3v1h-3z" />
+
+                      {/* Royal orb */}
+                      <circle cx="12" cy="4" r="1.5" opacity="0.9" />
                     </svg>
                   </button>
                 </div>

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -756,15 +756,14 @@ function ConjugationRow({
   const isIrregular = form.tags?.includes('irregular')
   const isPlural = form.tags?.includes('plurale') || ['noi', 'voi', 'loro'].includes(pronounDisplay)
   
-  // Determine colors based on gender variants and toggle state
-  // Determine colors based on gender variants and toggle state
+  // Determine colors based on gender variants, toggle state, AND formality
   const getColors = () => {
-    // Extract pronoun directly from tags (without helper)
+    // Extract pronoun directly from tags
     const pronoun = form.tags?.find(tag =>
       ['io', 'tu', 'lui', 'lei', 'noi', 'voi', 'loro'].includes(tag)
     )
 
-    // Check if this form has actual gender variants in the verb form
+    // Check if this form has actual gender variants in the verb form itself
     const hasVerbGenderVariants =
       form.tags?.includes('compound') &&
       (wordTags?.includes('essere-auxiliary') || form.base_form_id)
@@ -775,6 +774,18 @@ function ConjugationRow({
       form.tags?.includes('lei') ||
       pronoun === 'lui' ||
       pronoun === 'lei'
+
+    // Check if this is a formal context (tu/voi mapped to Lei/Loro)
+    const isFormalContext =
+      selectedFormality === 'formal' && (pronoun === 'tu' || pronoun === 'voi')
+
+    // Formal contexts get purple coloring
+    if (isFormalContext) {
+      return {
+        form: 'text-purple-600',
+        audio: 'bg-purple-600'
+      }
+    }
 
     if (audioPreference === 'form-only') {
       if (hasVerbGenderVariants) {

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -236,7 +236,7 @@ const loadConjugations = async () => {
     return pronoun || ''
   }
 
-  // Get translation based on audio preference and gender toggle - SIMPLIFIED
+  // Get translation based on audio preference and gender toggle - FIXED
   const getDynamicTranslation = (form) => {
     const pronoun = extractTagValue(form.tags, 'pronoun')
 
@@ -248,29 +248,41 @@ const loadConjugations = async () => {
     // Start from the original translation each time
     let translation = form.translation
 
-    // Check if this form has gender variants
+    // Check if this form has gender variants (compound tenses with ESSERE)
     const hasGenderVariants =
       word?.tags?.includes('essere-auxiliary') && form.tags?.includes('compound')
 
     if (audioPreference === 'form-only' && !hasGenderVariants) {
-      // Form-only + no gender variants: always show "he/she"
-      if (translation.toLowerCase().includes(' he ') || translation.startsWith('he ')) {
+      // Form-only + simple ESSERE verbs: show "he/she"
+      if (
+        translation.toLowerCase().includes('he ') ||
+        translation.toLowerCase().startsWith('he ')
+      ) {
         translation = translation
           .replace(/\bhe\b/gi, 'he/she')
           .replace(/^He\b/, 'He/she')
-      } else if (translation.toLowerCase().includes(' she ') || translation.startsWith('she ')) {
+      } else if (
+        translation.toLowerCase().includes('she ') ||
+        translation.toLowerCase().startsWith('she ')
+      ) {
         translation = translation
           .replace(/\bshe\b/gi, 'he/she')
           .replace(/^She\b/, 'He/she')
       }
-    } else {
-      // Either has gender variants or with-pronoun mode: show selected gender
+    } else if (hasGenderVariants || audioPreference === 'with-pronoun') {
+      // Compound tenses OR with-pronoun mode: show selected gender only
       if (selectedGender === 'male') {
+        // Show "he" - replace any existing "she" or "he/she" 
         translation = translation
+          .replace(/\bhe\/she\b/gi, 'he')
+          .replace(/^He\/she\b/, 'He')
           .replace(/\bshe\b/gi, 'he')
           .replace(/^She\b/, 'He')
       } else {
+        // Show "she" - replace any existing "he" or "he/she"
         translation = translation
+          .replace(/\bhe\/she\b/gi, 'she')
+          .replace(/^He\/she\b/, 'She')
           .replace(/\bhe\b/gi, 'she')
           .replace(/^He\b/, 'She')
       }

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -249,27 +249,39 @@ const loadConjugations = async () => {
 
       if (audioPreference === 'form-only' && !hasGenderVariants) {
         // Form-only mode for non-gender-variant forms: show "he/she"
+        // First normalize any existing gender-specific text, then replace
         translation = translation
-          .replace(/^he /i, 'he/she ')
-          .replace(/^she /i, 'he/she ')
-          .replace(/^He /g, 'He/she ')
-          .replace(/^She /g, 'He/she ')
+          .replace(/\bhe\b/gi, 'he/she')
+          .replace(/\bshe\b/gi, 'he/she')
+          .replace(/\bHe\b/g, 'He/she')
+          .replace(/\bShe\b/g, 'He/she')
+          // Clean up any double replacements
+          .replace(/he\/she\/she/gi, 'he/she')
+          .replace(/He\/she\/she/g, 'He/she')
       } else if (hasGenderVariants || audioPreference === 'with-pronoun') {
         // Gender-variant forms OR with-pronoun mode: show selected gender
         if (selectedGender === 'male') {
-          // Clean up any existing replacements first, then set to "he"
+          // First clean up any compound replacements, then set to male
           translation = translation
-            .replace(/he\/she /gi, 'he ')
-            .replace(/He\/she /g, 'He ')
-            .replace(/she /gi, 'he ')
-            .replace(/^She /g, 'He ')
+            .replace(/\bhe\/she\b/gi, 'he')
+            .replace(/\bHe\/she\b/g, 'He')
+            .replace(/\bshe\b/gi, 'he')
+            .replace(/\bShe\b/g, 'He')
+            // Clean up double replacements like "sshe" -> "she" -> "he"
+            .replace(/\bsshe\b/gi, 'she')
+            .replace(/\bSShe\b/g, 'She')
+            .replace(/\bshe\b/gi, 'he')
+            .replace(/\bShe\b/g, 'He')
         } else {
-          // Clean up any existing replacements first, then set to "she"
+          // First clean up any compound replacements, then set to female
           translation = translation
-            .replace(/he\/she /gi, 'she ')
-            .replace(/He\/she /g, 'She ')
-            .replace(/he /gi, 'she ')
-            .replace(/^He /g, 'She ')
+            .replace(/\bhe\/she\b/gi, 'she')
+            .replace(/\bHe\/she\b/g, 'She')
+            .replace(/\bhe\b/gi, 'she')
+            .replace(/\bHe\b/g, 'She')
+            // Clean up double replacements like "sshe"
+            .replace(/\bsshe\b/gi, 'she')
+            .replace(/\bSShe\b/g, 'She')
         }
       }
     }
@@ -503,9 +515,9 @@ const loadConjugations = async () => {
                   <div className="flex gap-2 justify-center">
                     <button
                       onClick={() => setSelectedGender('male')}
-                      disabled={!currentForms.some(form => form.tags?.includes('compound'))}
+                      disabled={audioPreference === 'form-only' && !currentForms.some(form => form.tags?.includes('compound'))}
                       className={`w-10 h-10 border-2 rounded-lg flex items-center justify-center text-lg transition-colors ${
-                        !currentForms.some(form => form.tags?.includes('compound'))
+                        (audioPreference === 'form-only' && !currentForms.some(form => form.tags?.includes('compound')))
                           ? 'border-gray-300 text-gray-300 bg-gray-100 cursor-not-allowed'
                           : selectedGender === 'male'
                               ? 'border-blue-500 bg-blue-500 text-white'
@@ -516,9 +528,9 @@ const loadConjugations = async () => {
                     </button>
                     <button
                       onClick={() => setSelectedGender('female')}
-                      disabled={!currentForms.some(form => form.tags?.includes('compound'))}
+                      disabled={audioPreference === 'form-only' && !currentForms.some(form => form.tags?.includes('compound'))}
                       className={`w-10 h-10 border-2 rounded-lg flex items-center justify-center text-lg transition-colors ${
-                        !currentForms.some(form => form.tags?.includes('compound'))
+                        (audioPreference === 'form-only' && !currentForms.some(form => form.tags?.includes('compound')))
                           ? 'border-gray-300 text-gray-300 bg-gray-100 cursor-not-allowed'
                           : selectedGender === 'female'
                               ? 'border-pink-500 bg-pink-500 text-white'

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -213,23 +213,40 @@ const loadConjugations = async () => {
     return currentForms.some(form => form.tags?.includes('compound'))
   }
 
-  // Get pronoun display text
+  // Get pronoun display based on selected gender toggle
   const getPronounDisplay = (form) => {
     const pronoun = extractTagValue(form.tags, 'pronoun')
-    
-    if (audioPreference === 'with-pronoun' && pronoun === 'lui') {
-      return selectedGender === 'male' ? 'lui' : 'lei'
-    }
-    if (audioPreference === 'with-pronoun' && pronoun === 'lei') {
-      return selectedGender === 'male' ? 'lui' : 'lei'
-    }
-    
-    // Handle lui/lei cases
+
+    // For 3rd person, show the selected gender
     if (pronoun === 'lui' || pronoun === 'lei') {
-      return audioPreference === 'form-only' ? 'lui/lei' : pronoun
+      return selectedGender === 'male' ? 'lui' : 'lei'
     }
-    
+
+    // For all other persons, show the base pronoun
     return pronoun || ''
+  }
+
+  // Get translation based on selected gender toggle
+  const getDynamicTranslation = (form) => {
+    const pronoun = extractTagValue(form.tags, 'pronoun')
+    let translation = form.translation
+
+    // For 3rd person, adjust translation based on selected gender
+    if (pronoun === 'lui' || pronoun === 'lei') {
+      if (selectedGender === 'male') {
+        // Ensure it says "he"
+        translation = translation
+          .replace(/she /gi, 'he ')
+          .replace(/^She /g, 'He ')
+      } else {
+        // Ensure it says "she"
+        translation = translation
+          .replace(/he /gi, 'she ')
+          .replace(/^He /g, 'She ')
+      }
+    }
+
+    return translation
   }
 
   // Get the appropriate form to display based on gender toggle
@@ -500,7 +517,7 @@ const loadConjugations = async () => {
                       return (
                         <ConjugationRow
                           key={form.id}
-                          form={displayForm}  // Use display form instead of base form
+                          form={{ ...displayForm, translation: getDynamicTranslation(displayForm) }}
                           audioText={getAudioText(form)}
                           pronounDisplay={getPronounDisplay(form)}
                           isCompound={compound}
@@ -521,7 +538,7 @@ const loadConjugations = async () => {
                       return (
                         <ConjugationRow
                           key={form.id}
-                          form={displayForm}  // Use display form instead of base form
+                          form={{ ...displayForm, translation: getDynamicTranslation(displayForm) }}
                           audioText={getAudioText(form)}
                           pronounDisplay={getPronounDisplay(form)}
                           isCompound={compound}

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -247,6 +247,7 @@ const loadConjugations = async () => {
 
     // Get the original translation
     let translation = form.translation
+    const startsWithCapital = /^[A-Z]/.test(translation.trim())
 
     // Check if this form has gender variants (compound tenses with ESSERE)
     const hasGenderVariants =
@@ -271,11 +272,14 @@ const loadConjugations = async () => {
       .replace(/\bHe\b/g, 'PLACEHOLDER')
       .replace(/\bShe\b/g, 'PLACEHOLDER')
 
-    const finalPronoun = translation.startsWith('PLACEHOLDER')
-      ? targetPronoun.charAt(0).toUpperCase() + targetPronoun.slice(1)
-      : targetPronoun
+    if (translation.startsWith('PLACEHOLDER')) {
+      const first = startsWithCapital
+        ? targetPronoun.charAt(0).toUpperCase() + targetPronoun.slice(1)
+        : targetPronoun
+      translation = translation.replace('PLACEHOLDER', first)
+    }
 
-    translation = translation.replace(/PLACEHOLDER/g, finalPronoun)
+    translation = translation.replace(/PLACEHOLDER/g, targetPronoun)
 
     return translation
   }

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react'
 import { supabase } from '../lib/supabase'
 import AudioButton from './AudioButton'
 import SectionHeading from './SectionHeading'
+import { VariantCalculator } from '../lib/variant-calculator'
 
 export default function ConjugationModal({ 
   isOpen, 
@@ -104,18 +105,24 @@ const loadConjugations = async () => {
         audio_filename: form.word_audio_metadata?.audio_filename || null,
         azure_voice_name: form.word_audio_metadata?.azure_voice_name || null
       }
-      
+
       console.log('🔍 Processed form:', {
         form_text: form.form_text,
         audio_metadata_id: form.audio_metadata_id,
         word_audio_metadata: form.word_audio_metadata,
         final_audio_filename: result.audio_filename
       })
-      
+
       return result
     })
-    
-    const groupedConjugations = groupConjugationsByMoodTense(processedData)
+
+    // Generate all forms (stored + calculated variants)
+    const allForms = VariantCalculator.getAllForms(processedData, word.tags || [])
+
+    console.log('🔍 All forms (stored + calculated):', allForms.length, 'total forms')
+    console.log('🔍 Calculated variants:', allForms.filter(f => f.tags?.includes('calculated-variant')))
+
+    const groupedConjugations = groupConjugationsByMoodTense(allForms)
     setConjugations(groupedConjugations)
     
   } catch (error) {

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -775,11 +775,10 @@ function ConjugationRow({
       pronoun === 'lui' ||
       pronoun === 'lei'
 
-    // Check if this is a formal context (tu/voi mapped to Lei/Loro)
-    const isFormalContext =
-      selectedFormality === 'formal' && (pronoun === 'tu' || pronoun === 'voi')
+    // CORRECT: Determine formal context based on displayed pronoun
+    const isFormalContext = pronounDisplay === 'Lei' || pronounDisplay === 'Loro'
 
-    // Formal contexts get purple coloring
+    // FORMAL CONTEXTS get purple color
     if (isFormalContext) {
       return {
         form: 'text-purple-600',

--- a/lib/audio-utils.js
+++ b/lib/audio-utils.js
@@ -124,13 +124,24 @@ export async function fallbackToTTS(text) {
       let voices = speechSynthesis.getVoices()
       
       if (voices.length === 0) {
+        let fired = false
         speechSynthesis.onvoiceschanged = () => {
+          fired = true
           voices = speechSynthesis.getVoices()
           setItalianVoice(voices)
           speakText()
         }
         speechSynthesis.speak(new SpeechSynthesisUtterance(''))
         speechSynthesis.cancel()
+
+        // Fallback in case onvoiceschanged never fires (iOS bug)
+        setTimeout(() => {
+          if (!fired) {
+            voices = speechSynthesis.getVoices()
+            setItalianVoice(voices)
+            speakText()
+          }
+        }, 500)
       } else {
         setItalianVoice(voices)
         speakText()

--- a/lib/audio-utils.js
+++ b/lib/audio-utils.js
@@ -49,15 +49,20 @@ export async function playAudio(wordId, italianText, audioFilename) {
 
       if (urlData && urlData.signedUrl) {
         console.log('DEBUG: Successfully created signed URL. Playing audio.')
-        const audio = new Audio(urlData.signedUrl)
-        
-        audio.onerror = (e) => {
-          console.error('DEBUG: Error playing pregenerated audio from URL:', e)
-          fallbackToTTS(italianText)
-        }
-        
-        await audio.play()
-        return { success: true, source: 'premium' }
+        return new Promise((resolve, reject) => {
+          const audio = new Audio(urlData.signedUrl)
+
+          audio.onended = () => resolve({ success: true, source: 'premium' })
+          audio.onerror = (e) => {
+            console.error('DEBUG: Error playing pregenerated audio from URL:', e)
+            fallbackToTTS(italianText).then(resolve).catch(reject)
+          }
+
+          audio.play().catch(err => {
+            console.error('DEBUG: Audio play failed:', err)
+            fallbackToTTS(italianText).then(resolve).catch(reject)
+          })
+        })
       } else {
         console.error('DEBUG: Error creating signed URL:', urlError)
       }
@@ -79,72 +84,62 @@ export async function playAudio(wordId, italianText, audioFilename) {
  */
 export async function fallbackToTTS(text) {
   console.log('DEBUG: Using TTS fallback for:', text)
-  
+
   return new Promise((resolve, reject) => {
     if ('speechSynthesis' in window) {
       const utterance = new SpeechSynthesisUtterance(text)
-      
+
       const setItalianVoice = (voices) => {
-        const italianVoices = voices.filter(voice => 
-          voice.lang.startsWith('it') || 
-          voice.lang.includes('IT') || 
+        const italianVoices = voices.filter(voice =>
+          voice.lang.startsWith('it') ||
+          voice.lang.includes('IT') ||
           voice.name.toLowerCase().includes('ital')
         )
-        
+
         if (italianVoices.length > 0) {
-          const preferredVoice = italianVoices.find(voice => 
-            voice.name.includes('Luca') || 
-            voice.name.includes('Alice') ||  
-            voice.name.includes('Federica') || 
+          const preferredVoice = italianVoices.find(voice =>
+            voice.name.includes('Luca') ||
+            voice.name.includes('Alice') ||
+            voice.name.includes('Federica') ||
             voice.name.includes('Italia')
           ) || italianVoices[0]
-          
+
           utterance.voice = preferredVoice
         }
-        
+
         utterance.lang = 'it-IT'
         utterance.rate = 0.9
         utterance.pitch = 1.0
       }
-      
-      const speakText = () => {
+
+      const speak = () => {
         utterance.onend = () => {
           resolve({ success: true, source: 'tts' })
         }
-        
+
         utterance.onerror = (event) => {
           console.error('DEBUG: Speech synthesis error:', event)
           reject(new Error('Speech synthesis failed'))
         }
-        
-        speechSynthesis.cancel()
-        setTimeout(() => speechSynthesis.speak(utterance), 100)
-      }
-      
-      let voices = speechSynthesis.getVoices()
-      
-      if (voices.length === 0) {
-        let fired = false
-        speechSynthesis.onvoiceschanged = () => {
-          fired = true
-          voices = speechSynthesis.getVoices()
-          setItalianVoice(voices)
-          speakText()
-        }
-        speechSynthesis.speak(new SpeechSynthesisUtterance(''))
-        speechSynthesis.cancel()
 
-        // Fallback in case onvoiceschanged never fires (iOS bug)
-        setTimeout(() => {
-          if (!fired) {
-            voices = speechSynthesis.getVoices()
-            setItalianVoice(voices)
-            speakText()
-          }
-        }, 500)
-      } else {
+        speechSynthesis.cancel()
+        speechSynthesis.speak(utterance)
+      }
+
+      const voices = speechSynthesis.getVoices()
+
+      if (voices.length > 0) {
         setItalianVoice(voices)
-        speakText()
+        speak()
+      } else {
+        // Attempt to load voices briefly, but speak regardless after delay
+        setTimeout(() => {
+          const retryVoices = speechSynthesis.getVoices()
+          if (retryVoices.length > 0) {
+            setItalianVoice(retryVoices)
+          }
+          speak()
+        }, 300)
       }
     } else {
       console.error('DEBUG: Speech synthesis not supported')

--- a/lib/variant-calculator.js
+++ b/lib/variant-calculator.js
@@ -1,301 +1,304 @@
 // lib/variant-calculator.js
-// Complete variant calculation system with morphological generators
+// Enhanced morphological transformation engine for Italian conjugations
+// Handles all participle patterns and gender agreement calculations
 
 export class VariantCalculator {
   
-  // Main detection function using existing tags
-  static needsVariants(word, wordTags, formTags = []) {
-    const patterns = [
-      this.checkEssereCompounds(wordTags, formTags),
-      this.checkCommonGender(wordTags),
-      this.checkAdjective4Forms(wordTags),
-      this.checkAdjective2Forms(wordTags),
-      this.checkParticipleAdjectives(formTags)
-    ].filter(Boolean);
-    
-    return patterns.length > 0 ? patterns[0] : null;
-  }
-  
-  // Detection functions
-  static checkEssereCompounds(wordTags, formTags) {
+  // MAIN DETECTION FUNCTION - Determines if gender variants are needed
+  static needsGenderVariants(wordTags, formTags = []) {
+    // Check for ESSERE auxiliary + compound tense combination
     if (wordTags.includes('essere-auxiliary') && formTags.includes('compound')) {
       return {
         type: 'essere-compound',
-        variants: ['masc-sing', 'fem-sing', 'masc-plur', 'fem-plur']
+        variants: ['fem-sing', 'fem-plur'] // Only calculate feminines from stored masculines
       };
     }
-    return null;
-  }
-  
-  static checkCommonGender(wordTags) {
-    if (wordTags.includes('common-gender')) {
+    
+    // Check for reflexive verbs (always use essere)
+    if (wordTags.includes('reflexive-verb') && formTags.includes('compound')) {
       return {
-        type: 'common-gender',
-        variants: ['masc-sing', 'fem-sing', 'masc-plur', 'fem-plur']
+        type: 'reflexive-compound',
+        variants: ['fem-sing', 'fem-plur']
       };
     }
-    return null;
+    
+    return null; // No gender variants needed
   }
   
-  static checkAdjective4Forms(wordTags) {
-    if (wordTags.includes('form-4')) {
-      return {
-        type: 'adjective-4',
-        variants: ['masc-sing', 'fem-sing', 'masc-plur', 'fem-plur']
-      };
-    }
-    return null;
+  // COMPREHENSIVE PARTICIPLE TRANSFORMATION RULES
+  static transformParticiple(masculineForm, targetGender, targetNumber) {
+    // Extract participle from compound form (e.g., "sono andato" → "andato")
+    const participle = this.extractParticiple(masculineForm);
+    if (!participle) return masculineForm;
+    
+    // Transform the participle
+    const transformedParticiple = this.applyParticipleRules(participle, targetGender, targetNumber);
+    
+    // Reconstruct the full form
+    return masculineForm.replace(participle, transformedParticiple);
   }
   
-  static checkAdjective2Forms(wordTags) {
-    if (wordTags.includes('form-2')) {
-      return {
-        type: 'adjective-2', 
-        variants: ['singular', 'plural']
-      };
+  // EXTRACT PARTICIPLE FROM COMPOUND FORM
+  static extractParticiple(compoundForm) {
+    // Handle various compound patterns
+    const parts = compoundForm.trim().split(/\s+/);
+    
+    // For most compounds, participle is the last word
+    if (parts.length >= 2) {
+      return parts[parts.length - 1];
     }
-    return null;
+    
+    // For single words, assume it's already a participle
+    return compoundForm.trim();
   }
   
-  static checkParticipleAdjectives(formTags) {
-    if (formTags.includes('participio-passato') && !formTags.includes('compound')) {
-      return {
-        type: 'participle-adjective',
-        variants: ['masc-sing', 'fem-sing', 'masc-plur', 'fem-plur'] 
-      };
-    }
-    return null;
-  }
-
-  // MORPHOLOGICAL GENERATORS - Convert base text to variants
-  
-  static generateVariants(baseText, variantType) {
-    switch(variantType.type) {
-      case 'essere-compound':
-        return this.generateEssereCompoundVariants(baseText);
-      case 'common-gender':
-        return this.generateCommonGenderVariants(baseText);
-      case 'adjective-4':
-        return this.generateAdjective4Variants(baseText);
-      case 'adjective-2':
-        return this.generateAdjective2Variants(baseText);
-      case 'participle-adjective':
-        return this.generateParticipleVariants(baseText);
-      default:
-        return {};
-    }
-  }
-
-  // Generate essere compound variants: "sono andato" → "sono andata", "sono andati", "sono andate"
-  static generateEssereCompoundVariants(baseText) {
-    const variants = {};
+  // COMPREHENSIVE PARTICIPLE MORPHOLOGICAL RULES
+  static applyParticipleRules(participle, targetGender, targetNumber) {
+    // Handle all possible participle patterns from your specification
     
-    // Extract auxiliary and participle: "sono andato" → ["sono", "andato"]
-    const parts = baseText.trim().split(/\s+/);
-    if (parts.length < 2) return variants;
-    
-    const auxiliary = parts.slice(0, -1).join(' '); // "sono" or "siamo stati"
-    const participle = parts[parts.length - 1]; // "andato"
-    
-    // Transform participle ending: -o → -a/-i/-e
-    if (participle.endsWith('o')) {
-      const stem = participle.slice(0, -1); // "andat"
-      
-      variants['masc-sing'] = baseText; // Original form
-      variants['fem-sing'] = `${auxiliary} ${stem}a`;  // "sono andata"
-      variants['masc-plur'] = `${auxiliary} ${stem}i`; // "sono andati"
-      variants['fem-plur'] = `${auxiliary} ${stem}e`;  // "sono andate"
+    // REGULAR -ATO PATTERN (andato, parlato, lavato)
+    if (participle.endsWith('ato')) {
+      const stem = participle.slice(0, -3); // Remove 'ato'
+      if (targetGender === 'feminine' && targetNumber === 'singular') return stem + 'ata';
+      if (targetGender === 'masculine' && targetNumber === 'plural') return stem + 'ati';
+      if (targetGender === 'feminine' && targetNumber === 'plural') return stem + 'ate';
+      return participle; // masculine singular (original)
     }
     
-    return variants;
-  }
-
-  // Generate common gender variants: "cantante" → "la cantante", "i cantanti", "le cantanti"
-  static generateCommonGenderVariants(baseText) {
-    const variants = {};
-    const word = baseText.trim();
-    
-    // Generate article + word combinations
-    variants['masc-sing'] = this.addDefiniteArticle(word, 'masculine', false);  // "il cantante"
-    variants['fem-sing'] = this.addDefiniteArticle(word, 'feminine', false);   // "la cantante"
-    
-    // Generate plural forms
-    const plural = this.makePlural(word);
-    variants['masc-plur'] = this.addDefiniteArticle(plural, 'masculine', true);  // "i cantanti"
-    variants['fem-plur'] = this.addDefiniteArticle(plural, 'feminine', true);    // "le cantanti"
-    
-    return variants;
-  }
-
-  // Generate 4-form adjective variants: "bello" → "bella", "belli", "belle"
-  static generateAdjective4Variants(baseText) {
-    const variants = {};
-    const word = baseText.trim();
-    
-    // Handle -o ending adjectives
-    if (word.endsWith('o')) {
-      const stem = word.slice(0, -1); // "bell"
-      
-      variants['masc-sing'] = word;           // "bello"
-      variants['fem-sing'] = `${stem}a`;     // "bella"
-      variants['masc-plur'] = `${stem}i`;    // "belli"
-      variants['fem-plur'] = `${stem}e`;     // "belle"
+    // REGULAR -ITO PATTERN (finito, partito, servito)
+    if (participle.endsWith('ito')) {
+      const stem = participle.slice(0, -3); // Remove 'ito'
+      if (targetGender === 'feminine' && targetNumber === 'singular') return stem + 'ita';
+      if (targetGender === 'masculine' && targetNumber === 'plural') return stem + 'iti';
+      if (targetGender === 'feminine' && targetNumber === 'plural') return stem + 'ite';
+      return participle; // masculine singular (original)
     }
     
-    return variants;
-  }
-
-  // Generate 2-form adjective variants: "grande" → "grandi"
-  static generateAdjective2Variants(baseText) {
-    const variants = {};
-    const word = baseText.trim();
+    // REGULAR -UTO PATTERN (venuto, caduto, piaciuto)
+    if (participle.endsWith('uto')) {
+      const stem = participle.slice(0, -3); // Remove 'uto'
+      if (targetGender === 'feminine' && targetNumber === 'singular') return stem + 'uta';
+      if (targetGender === 'masculine' && targetNumber === 'plural') return stem + 'uti';
+      if (targetGender === 'feminine' && targetNumber === 'plural') return stem + 'ute';
+      return participle; // masculine singular (original)
+    }
     
-    variants['singular'] = word;                    // "grande"
-    variants['plural'] = this.makePlural(word);    // "grandi"
+    // IRREGULAR -TO PATTERN (fatto, detto, letto)
+    if (participle.endsWith('tto')) {
+      const stem = participle.slice(0, -3); // Remove 'tto'
+      if (targetGender === 'feminine' && targetNumber === 'singular') return stem + 'tta';
+      if (targetGender === 'masculine' && targetNumber === 'plural') return stem + 'tti';
+      if (targetGender === 'feminine' && targetNumber === 'plural') return stem + 'tte';
+      return participle; // masculine singular (original)
+    }
     
-    return variants;
-  }
-
-  // Generate participle adjective variants: "stanco" → "stanca", "stanchi", "stanche"
-  static generateParticipleVariants(baseText) {
-    // Same logic as 4-form adjectives
-    return this.generateAdjective4Variants(baseText);
-  }
-
-  // HELPER FUNCTIONS - Italian morphological rules
-  
-  // Make plural form following Italian rules
-  static makePlural(word) {
-    if (word.endsWith('o')) return word.slice(0, -1) + 'i';    // libro → libri
-    if (word.endsWith('a')) return word.slice(0, -1) + 'e';    // casa → case
-    if (word.endsWith('e')) return word.slice(0, -1) + 'i';    // cantante → cantanti
+    // IRREGULAR -SO PATTERN (preso, acceso, difeso)
+    if (participle.endsWith('so')) {
+      const stem = participle.slice(0, -2); // Remove 'so'
+      if (targetGender === 'feminine' && targetNumber === 'singular') return stem + 'sa';
+      if (targetGender === 'masculine' && targetNumber === 'plural') return stem + 'si';
+      if (targetGender === 'feminine' && targetNumber === 'plural') return stem + 'se';
+      return participle; // masculine singular (original)
+    }
     
-    // Handle special cases
-    if (word.endsWith('co')) return word.slice(0, -2) + 'chi'; // amico → amici
-    if (word.endsWith('go')) return word.slice(0, -2) + 'ghi'; // luogo → luoghi
-    if (word.endsWith('ca')) return word.slice(0, -2) + 'che'; // amica → amiche
-    if (word.endsWith('ga')) return word.slice(0, -2) + 'ghe'; // collega → colleghe
+    // IRREGULAR -STO PATTERN (visto, posto)
+    if (participle.endsWith('sto')) {
+      const stem = participle.slice(0, -3); // Remove 'sto'
+      if (targetGender === 'feminine' && targetNumber === 'singular') return stem + 'sta';
+      if (targetGender === 'masculine' && targetNumber === 'plural') return stem + 'sti';
+      if (targetGender === 'feminine' && targetNumber === 'plural') return stem + 'ste';
+      return participle; // masculine singular (original)
+    }
     
-    // Default: no change (invariable)
-    return word;
+    // CONSONANT + O PATTERN (morto, nato, stato)
+    if (participle.endsWith('to') && !participle.endsWith('ato') && !participle.endsWith('ito') && !participle.endsWith('uto')) {
+      const stem = participle.slice(0, -2); // Remove 'to'
+      if (targetGender === 'feminine' && targetNumber === 'singular') return stem + 'ta';
+      if (targetGender === 'masculine' && targetNumber === 'plural') return stem + 'ti';
+      if (targetGender === 'feminine' && targetNumber === 'plural') return stem + 'te';
+      return participle; // masculine singular (original)
+    }
+    
+    // FALLBACK: Return original if no pattern matches
+    console.warn(`Unknown participle pattern: ${participle}`);
+    return participle;
   }
   
-  // Add definite article based on gender and phonetic rules
-  static addDefiniteArticle(word, gender, isPlural) {
-    const firstChar = word.charAt(0).toLowerCase();
-    const firstTwo = word.substring(0, 2).toLowerCase();
+  // PHONETIC TRANSFORMATION RULES
+  static transformPhonetic(originalPhonetic, originalParticiple, transformedParticiple) {
+    if (!originalPhonetic || originalParticiple === transformedParticiple) {
+      return originalPhonetic;
+    }
     
-    // Check for consonant clusters after 's'
-    const consonantAfterS = word.length > 1 && 
-      /[bcdfghjklmnpqrstvwxyz]/.test(word.charAt(1));
+    // Apply phonetic transformations based on ending changes
+    const originalEnding = originalParticiple.slice(-3);
+    const transformedEnding = transformedParticiple.slice(-3);
     
-    if (isPlural) {
-      if (gender === 'masculine') {
-        // Plural masculine: gli or i
-        if (/[aeiou]/.test(firstChar) || 
-            ['gn','ps','sc','sp','st','x','z'].includes(firstTwo) ||
-            (firstChar === 's' && consonantAfterS)) {
-          return `gli ${word}`;
+    // Phonetic transformation patterns
+    const phoneticRules = {
+      // -ato patterns
+      'ato': { 'ata': 'toh→tah', 'ati': 'toh→tee', 'ate': 'toh→teh' },
+      // -ito patterns  
+      'ito': { 'ita': 'toh→tah', 'iti': 'toh→tee', 'ite': 'toh→teh' },
+      // -uto patterns
+      'uto': { 'uta': 'toh→tah', 'uti': 'toh→tee', 'ute': 'toh→teh' },
+      // -tto patterns
+      'tto': { 'tta': 'toh→tah', 'tti': 'toh→tee', 'tte': 'toh→teh' },
+      // -so patterns
+      'so': { 'sa': 'soh→sah', 'si': 'soh→see', 'se': 'soh→seh' },
+      // -sto patterns
+      'sto': { 'sta': 'stoh→stah', 'sti': 'stoh→stee', 'ste': 'stoh→steh' }
+    };
+    
+    // Find matching rule and apply transformation
+    for (const [pattern, rules] of Object.entries(phoneticRules)) {
+      if (originalEnding.includes(pattern.slice(-2))) {
+        const rule = rules[transformedEnding];
+        if (rule) {
+          const [from, to] = rule.split('→');
+          return originalPhonetic.replace(from, to);
         }
-        return `i ${word}`;
-      } else {
-        // Plural feminine: always le
-        return `le ${word}`;
-      }
-    } else {
-      // Singular
-      if (gender === 'masculine') {
-        // Singular masculine: lo or il
-        if (/[aeiou]/.test(firstChar) || 
-            ['gn','ps','sc','sp','st','x','z'].includes(firstTwo) ||
-            (firstChar === 's' && consonantAfterS)) {
-          return `lo ${word}`;
-        }
-        return `il ${word}`;
-      } else {
-        // Singular feminine: la or l'
-        if (/[aeiou]/.test(firstChar)) {
-          return `l'${word}`;
-        }
-        return `la ${word}`;
       }
     }
-  }
-
-  // COMPLETE VARIANT GENERATION - Main public interface
-  
-  static calculateAllVariants(word, form = null) {
-    const wordTags = word.tags || [];
-    const formTags = form ? (form.tags || []) : [];
     
-    // Check if variants are needed
-    const variantPattern = this.needsVariants(word, wordTags, formTags);
+    return originalPhonetic; // Return original if no rule matches
+  }
+  
+  // IPA TRANSFORMATION RULES
+  static transformIPA(originalIPA, originalParticiple, transformedParticiple) {
+    if (!originalIPA || originalParticiple === transformedParticiple) {
+      return originalIPA;
+    }
+    
+    // IPA transformation patterns
+    const ipaRules = {
+      'o/': 'a/', // Vowel change o→a
+      'i/': 'i/', // Plural masculine stays i
+      'e/': 'e/'  // Plural feminine becomes e
+    };
+    
+    // Apply appropriate IPA transformation based on ending
+    if (transformedParticiple.endsWith('a')) {
+      return originalIPA.replace(/o\//, 'a/');
+    } else if (transformedParticiple.endsWith('i')) {
+      return originalIPA.replace(/o\//, 'i/');
+    } else if (transformedParticiple.endsWith('e')) {
+      return originalIPA.replace(/o\//, 'e/');
+    }
+    
+    return originalIPA; // Return original if no transformation needed
+  }
+  
+  // MAIN CALCULATION FUNCTION - Generates all gender variants
+  static calculateGenderVariants(storedForm, wordTags) {
+    const variantPattern = this.needsGenderVariants(wordTags, storedForm.tags || []);
     if (!variantPattern) return null;
     
-    // Use form text if available, otherwise word text
-    const baseText = form ? form.form_text : word.italian;
-    
-    // Generate actual variant texts
-    const variantTexts = this.generateVariants(baseText, variantPattern);
-    
-    // Convert to complete variant objects with metadata
     const variants = [];
     
-    Object.entries(variantTexts).forEach(([variantType, text]) => {
-      if (text !== baseText) { // Don't include the base form as a variant
-        variants.push({
-          variant_type: variantType,
-          form_text: text,
-          pattern_type: variantPattern.type,
-          base_text: baseText,
-          // Generate appropriate tags for this variant
-          tags: this.generateVariantTags(variantType, variantPattern.type, wordTags, formTags)
-        });
-      }
-    });
+    // Generate feminine singular variant
+    if (variantPattern.variants.includes('fem-sing')) {
+      const femSingForm = this.transformParticiple(storedForm.form_text, 'feminine', 'singular');
+      const femSingPhonetic = this.transformPhonetic(storedForm.phonetic_form, storedForm.form_text, femSingForm);
+      const femSingIPA = this.transformIPA(storedForm.ipa, storedForm.form_text, femSingForm);
+      
+      variants.push({
+        variant_type: 'fem-sing',
+        form_text: femSingForm,
+        phonetic_form: femSingPhonetic,
+        ipa: femSingIPA,
+        translation: storedForm.translation, // Translation stays the same
+        tags: [...(storedForm.tags || []), 'feminine', 'singolare', 'calculated-variant'],
+        base_form_id: storedForm.id,
+        pattern_type: variantPattern.type
+      });
+    }
+    
+    // Generate feminine plural variant
+    if (variantPattern.variants.includes('fem-plur')) {
+      const femPlurForm = this.transformParticiple(storedForm.form_text, 'feminine', 'plural');
+      const femPlurPhonetic = this.transformPhonetic(storedForm.phonetic_form, storedForm.form_text, femPlurForm);
+      const femPlurIPA = this.transformIPA(storedForm.ipa, storedForm.form_text, femPlurForm);
+      
+      variants.push({
+        variant_type: 'fem-plur',
+        form_text: femPlurForm,
+        phonetic_form: femPlurPhonetic,
+        ipa: femPlurIPA,
+        translation: storedForm.translation, // Translation stays the same
+        tags: [...(storedForm.tags || []), 'feminine', 'plurale', 'calculated-variant'],
+        base_form_id: storedForm.id,
+        pattern_type: variantPattern.type
+      });
+    }
     
     return variants.length > 0 ? variants : null;
   }
   
-  // Generate appropriate tags for calculated variants
-  static generateVariantTags(variantType, patternType, baseWordTags, baseFormTags) {
-    const tags = [...baseFormTags]; // Start with base form tags
+  // UTILITY FUNCTION - Check if form needs gender variants
+  static needsCalculation(storedForm, wordTags) {
+    return this.needsGenderVariants(wordTags, storedForm.tags || []) !== null;
+  }
+  
+  // UTILITY FUNCTION - Get all forms (stored + calculated)
+  static getAllForms(storedForms, wordTags) {
+    const allForms = [...storedForms]; // Start with stored forms
     
-    // Add variant-specific tags
-    switch (patternType) {
-      case 'essere-compound':
-        // Keep all base tags, add gender/number specific tags
-        if (variantType === 'fem-sing') tags.push('feminine', 'singolare');
-        if (variantType === 'masc-plur') tags.push('masculine', 'plurale');
-        if (variantType === 'fem-plur') tags.push('feminine', 'plurale');
-        break;
-        
-      case 'common-gender':
-        // Add article and gender/number tags
-        tags.push('with-article');
-        if (variantType === 'masc-sing') tags.push('masculine', 'singolare');
-        if (variantType === 'fem-sing') tags.push('feminine', 'singolare');
-        if (variantType === 'masc-plur') tags.push('masculine', 'plurale');
-        if (variantType === 'fem-plur') tags.push('feminine', 'plurale');
-        break;
-        
-      case 'adjective-4':
-      case 'participle-adjective':
-        // Add agreement tags
-        if (variantType === 'fem-sing') tags.push('feminine', 'singolare');
-        if (variantType === 'masc-plur') tags.push('masculine', 'plurale');
-        if (variantType === 'fem-plur') tags.push('feminine', 'plurale');
-        break;
-        
-      case 'adjective-2':
-        // Add number tag
-        if (variantType === 'plural') tags.push('plurale');
-        break;
-    }
+    storedForms.forEach(storedForm => {
+      const variants = this.calculateGenderVariants(storedForm, wordTags);
+      if (variants) {
+        allForms.push(...variants);
+      }
+    });
     
-    // Mark as calculated variant
-    tags.push('calculated-variant');
+    return allForms;
+  }
+}
+
+// TESTING UTILITIES (Remove in production)
+export class VariantCalculatorTest {
+  static testTransformations() {
+    console.log('🧪 Testing Participle Transformations:');
     
-    return tags;
+    const testCases = [
+      { input: 'andato', fem_sing: 'andata', masc_plur: 'andati', fem_plur: 'andate' },
+      { input: 'finito', fem_sing: 'finita', masc_plur: 'finiti', fem_plur: 'finite' },
+      { input: 'venuto', fem_sing: 'venuta', masc_plur: 'venuti', fem_plur: 'venute' },
+      { input: 'fatto', fem_sing: 'fatta', masc_plur: 'fatti', fem_plur: 'fatte' },
+      { input: 'preso', fem_sing: 'presa', masc_plur: 'presi', fem_plur: 'prese' },
+      { input: 'visto', fem_sing: 'vista', masc_plur: 'visti', fem_plur: 'viste' },
+      { input: 'morto', fem_sing: 'morta', masc_plur: 'morti', fem_plur: 'morte' }
+    ];
+    
+    testCases.forEach(testCase => {
+      const femSing = VariantCalculator.applyParticipleRules(testCase.input, 'feminine', 'singular');
+      const mascPlur = VariantCalculator.applyParticipleRules(testCase.input, 'masculine', 'plural');
+      const femPlur = VariantCalculator.applyParticipleRules(testCase.input, 'feminine', 'plural');
+      
+      console.log(`${testCase.input}: ${femSing} ${mascPlur} ${femPlur}`, 
+        femSing === testCase.fem_sing && mascPlur === testCase.masc_plur && femPlur === testCase.fem_plur ? '✅' : '❌');
+    });
+  }
+  
+  static testCompoundTransformations() {
+    console.log('🧪 Testing Compound Form Transformations:');
+    
+    const testCases = [
+      { input: 'sono andato', fem_sing: 'sono andata' },
+      { input: 'è finito', fem_sing: 'è finita' },
+      { input: 'siamo venuti', fem_plur: 'siamo venute' },
+      { input: 'mi sono lavato', fem_sing: 'mi sono lavata' }
+    ];
+    
+    testCases.forEach(testCase => {
+      if (testCase.fem_sing) {
+        const result = VariantCalculator.transformParticiple(testCase.input, 'feminine', 'singular');
+        console.log(`${testCase.input} → ${result}`, result === testCase.fem_sing ? '✅' : '❌');
+      }
+      if (testCase.fem_plur) {
+        const result = VariantCalculator.transformParticiple(testCase.input, 'feminine', 'plural');
+        console.log(`${testCase.input} → ${result}`, result === testCase.fem_plur ? '✅' : '❌');
+      }
+    });
   }
 }

--- a/lib/variant-calculator.js
+++ b/lib/variant-calculator.js
@@ -6,24 +6,30 @@ export class VariantCalculator {
   
   // MAIN DETECTION FUNCTION - Determines if gender variants are needed
   static needsGenderVariants(wordTags, formTags = []) {
-    // Check for ESSERE auxiliary + compound tense combination
-    if (wordTags.includes('essere-auxiliary') && formTags.includes('compound')) {
-      return {
-        type: 'essere-compound',
-        variants: ['fem-sing', 'fem-plur'] // Only calculate feminines from stored masculines
-      };
-    }
-    
-    // Check for reflexive verbs (always use essere)
-    if (wordTags.includes('reflexive-verb') && formTags.includes('compound')) {
-      return {
-        type: 'reflexive-compound',
-        variants: ['fem-sing', 'fem-plur']
-      };
-    }
-    
-    return null; // No gender variants needed
+    // Only for ESSERE auxiliary verbs
+    if (!wordTags.includes('essere-auxiliary')) return null;
+
+    // Must be a compound tense (uses past participle, not gerund)
+    if (!formTags.includes('compound')) return null;
+
+    // KEEP progressive forms but SKIP the ones that use gerunds
+    // Present progressive (sto andando) = gerund = NO gender variants
+    if (formTags.includes('presente-progressivo')) return null;
+
+    // Past progressive (stavo andando) = gerund = NO gender variants
+    if (formTags.includes('imperfetto-progressivo') || formTags.includes('passato-progressivo')) return null;
+
+    // INCLUDE compound forms that use past participles:
+    // - Passato prossimo: "sono andato" → "sono andata" ✅
+    // - Compound gerunds: "essendo andato" → "essendo andata" ✅
+    // - Future perfect: "sarò andato" → "sarò andata" ✅
+
+    return {
+      type: 'essere-compound',
+      variants: ['fem-sing', 'fem-plur']
+    };
   }
+
   
   // COMPREHENSIVE PARTICIPLE TRANSFORMATION RULES
   static transformParticiple(masculineForm, targetGender, targetNumber) {
@@ -193,47 +199,50 @@ export class VariantCalculator {
   static calculateGenderVariants(storedForm, wordTags) {
     const variantPattern = this.needsGenderVariants(wordTags, storedForm.tags || []);
     if (!variantPattern) return null;
-    
+
     const variants = [];
-    
-    // Generate feminine singular variant
-    if (variantPattern.variants.includes('fem-sing')) {
-      const femSingForm = this.transformParticiple(storedForm.form_text, 'feminine', 'singular');
-      const femSingPhonetic = this.transformPhonetic(storedForm.phonetic_form, storedForm.form_text, femSingForm);
-      const femSingIPA = this.transformIPA(storedForm.ipa, storedForm.form_text, femSingForm);
-      
-      variants.push({
-        variant_type: 'fem-sing',
-        form_text: femSingForm,
-        phonetic_form: femSingPhonetic,
-        ipa: femSingIPA,
-        translation: storedForm.translation, // Translation stays the same
-        tags: [...(storedForm.tags || []), 'feminine', 'singolare', 'calculated-variant'],
-        base_form_id: storedForm.id,
-        pattern_type: variantPattern.type
-      });
-    }
-    
-    // Generate feminine plural variant
-    if (variantPattern.variants.includes('fem-plur')) {
+
+    // Determine if this is plural from stored form tags
+    const isPlural = storedForm.tags?.includes('plurale') ||
+                     storedForm.tags?.some(tag => ['noi', 'voi', 'loro'].includes(tag));
+
+    if (isPlural) {
+      // For plural stored forms, only calculate feminine plural
       const femPlurForm = this.transformParticiple(storedForm.form_text, 'feminine', 'plural');
       const femPlurPhonetic = this.transformPhonetic(storedForm.phonetic_form, storedForm.form_text, femPlurForm);
       const femPlurIPA = this.transformIPA(storedForm.ipa, storedForm.form_text, femPlurForm);
-      
+
       variants.push({
         variant_type: 'fem-plur',
         form_text: femPlurForm,
         phonetic_form: femPlurPhonetic,
         ipa: femPlurIPA,
-        translation: storedForm.translation, // Translation stays the same
-        tags: [...(storedForm.tags || []), 'feminine', 'plurale', 'calculated-variant'],
+        translation: storedForm.translation,
+        tags: [...(storedForm.tags || []), 'feminine', 'calculated-variant'],
+        base_form_id: storedForm.id,
+        pattern_type: variantPattern.type
+      });
+    } else {
+      // For singular stored forms, only calculate feminine singular
+      const femSingForm = this.transformParticiple(storedForm.form_text, 'feminine', 'singular');
+      const femSingPhonetic = this.transformPhonetic(storedForm.phonetic_form, storedForm.form_text, femSingForm);
+      const femSingIPA = this.transformIPA(storedForm.ipa, storedForm.form_text, femSingForm);
+
+      variants.push({
+        variant_type: 'fem-sing',
+        form_text: femSingForm,
+        phonetic_form: femSingPhonetic,
+        ipa: femSingIPA,
+        translation: storedForm.translation,
+        tags: [...(storedForm.tags || []), 'feminine', 'calculated-variant'],
         base_form_id: storedForm.id,
         pattern_type: variantPattern.type
       });
     }
-    
+
     return variants.length > 0 ? variants : null;
   }
+
   
   // UTILITY FUNCTION - Check if form needs gender variants
   static needsCalculation(storedForm, wordTags) {

--- a/lib/variant-calculator.js
+++ b/lib/variant-calculator.js
@@ -60,15 +60,40 @@ export class VariantCalculator {
   
   // COMPREHENSIVE PARTICIPLE MORPHOLOGICAL RULES
   static applyParticipleRules(participle, targetGender, targetNumber) {
-    // Handle all possible participle patterns from your specification
-    
+    console.log('🔍 Transforming participle:', participle, 'to', targetGender, targetNumber);
+
     // REGULAR -ATO PATTERN (andato, parlato, lavato)
     if (participle.endsWith('ato')) {
       const stem = participle.slice(0, -3); // Remove 'ato'
-      if (targetGender === 'feminine' && targetNumber === 'singular') return stem + 'ata';
-      if (targetGender === 'masculine' && targetNumber === 'plural') return stem + 'ati';
-      if (targetGender === 'feminine' && targetNumber === 'plural') return stem + 'ate';
+      if (targetGender === 'feminine' && targetNumber === 'singular') {
+        const result = stem + 'ata';
+        console.log('✅ -ato fem-sing:', participle, '→', result);
+        return result;
+      }
+      if (targetGender === 'masculine' && targetNumber === 'plural') {
+        const result = stem + 'ati';
+        console.log('✅ -ato masc-plur:', participle, '→', result);
+        return result;
+      }
+      if (targetGender === 'feminine' && targetNumber === 'plural') {
+        const result = stem + 'ate';
+        console.log('✅ -ato fem-plur:', participle, '→', result);
+        return result;
+      }
+      console.log('✅ -ato unchanged:', participle);
       return participle; // masculine singular (original)
+    }
+
+    // REGULAR -ATI PATTERN (for plural stored forms)
+    if (participle.endsWith('ati')) {
+      const stem = participle.slice(0, -3); // Remove 'ati'
+      if (targetGender === 'feminine' && targetNumber === 'plural') {
+        const result = stem + 'ate';
+        console.log('✅ -ati fem-plur:', participle, '→', result);
+        return result;
+      }
+      console.log('✅ -ati unchanged:', participle);
+      return participle; // masculine plural (original)
     }
     
     // REGULAR -ITO PATTERN (finito, partito, servito)


### PR DESCRIPTION
## Summary
- replace variant-calculator with an extended engine supporting many participle endings
- generate feminine variants in ConjugationModal using VariantCalculator

## Testing
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6878cdc84a148329b626f0207794d14b