### PR TITLE
Add gender + translation integration

### DIFF
--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -305,19 +305,8 @@ const loadWordTranslations = async () => {
 
     console.log('✅ Translation filtered forms:', translationFilteredForms.length)
 
-    // Apply gender variants if needed using the filtered base forms
-    const allFormsWithVariants = VariantCalculator.getAllForms(
-      translationFilteredForms,
-      word.tags || []
-    )
-
-    console.log('🎭 Final forms with variants:', allFormsWithVariants.length)
-    console.log(
-      '🎭 Sample variant form:',
-      allFormsWithVariants.find(f => f.tags?.includes('calculated-variant'))
-    )
-
-    return allFormsWithVariants
+    // Return only the base forms. Gender variants are applied dynamically
+    return translationFilteredForms
   }
 
 
@@ -940,15 +929,24 @@ const loadWordTranslations = async () => {
                         console.log('🎭 STEP 2 FIXED: Gender button clicked - Male')
                         setSelectedGender('male')
                       }}
-                      disabled={!hasGenderVariantsInCurrentMoodTense()}
+                      disabled={
+                        audioPreference === 'form-only' &&
+                        !hasGenderVariantsInCurrentMoodTense()
+                      }
                       className={`w-10 h-10 border-2 rounded-lg flex items-center justify-center text-lg transition-colors ${
+                        audioPreference === 'form-only' &&
                         !hasGenderVariantsInCurrentMoodTense()
                           ? 'border-gray-300 text-gray-300 bg-gray-100 cursor-not-allowed'
                           : selectedGender === 'male'
                               ? 'border-blue-500 bg-blue-500 text-white'
                               : 'border-blue-500 text-blue-500 bg-white hover:bg-blue-50'
                       }`}
-                      title={hasGenderVariantsInCurrentMoodTense() ? 'Select masculine gender' : 'No gender variants in this tense'}
+                      title={
+                        audioPreference === 'form-only' &&
+                        !hasGenderVariantsInCurrentMoodTense()
+                          ? 'No gender variants in this tense'
+                          : 'Select masculine gender'
+                      }
                     >
                       ♂
                     </button>
@@ -957,15 +955,24 @@ const loadWordTranslations = async () => {
                         console.log('🎭 STEP 2 FIXED: Gender button clicked - Female')
                         setSelectedGender('female')
                       }}
-                      disabled={!hasGenderVariantsInCurrentMoodTense()}
+                      disabled={
+                        audioPreference === 'form-only' &&
+                        !hasGenderVariantsInCurrentMoodTense()
+                      }
                       className={`w-10 h-10 border-2 rounded-lg flex items-center justify-center text-lg transition-colors ${
+                        audioPreference === 'form-only' &&
                         !hasGenderVariantsInCurrentMoodTense()
                           ? 'border-gray-300 text-gray-300 bg-gray-100 cursor-not-allowed'
                           : selectedGender === 'female'
                               ? 'border-pink-500 bg-pink-500 text-white'
                               : 'border-pink-500 text-pink-500 bg-white hover:bg-pink-50'
                       }`}
-                      title={hasGenderVariantsInCurrentMoodTense() ? 'Select feminine gender' : 'No gender variants in this tense'}
+                      title={
+                        audioPreference === 'form-only' &&
+                        !hasGenderVariantsInCurrentMoodTense()
+                          ? 'No gender variants in this tense'
+                          : 'Select feminine gender'
+                      }
                     >
                       ♀
                     </button>

--- a/lib/variant-calculator.js
+++ b/lib/variant-calculator.js
@@ -240,6 +240,9 @@ export class VariantCalculator {
         phonetic_form: femPlurPhonetic,
         ipa: femPlurIPA,
         translation: storedForm.translation,
+        form_translations: storedForm.form_translations
+          ? storedForm.form_translations.map(ft => ({ ...ft }))
+          : [],
         tags: [...(storedForm.tags || []), 'feminine', 'calculated-variant'],
         base_form_id: storedForm.id,
         pattern_type: variantPattern.type
@@ -256,6 +259,9 @@ export class VariantCalculator {
         phonetic_form: femSingPhonetic,
         ipa: femSingIPA,
         translation: storedForm.translation,
+        form_translations: storedForm.form_translations
+          ? storedForm.form_translations.map(ft => ({ ...ft }))
+          : [],
         tags: [...(storedForm.tags || []), 'feminine', 'calculated-variant'],
         base_form_id: storedForm.id,
         pattern_type: variantPattern.type


### PR DESCRIPTION
## Summary
- enrich conjugation load query with full translation data
- add helper to look up translation for selected meaning
- update gender toggle logic to work with translation filtering
- adjust dynamic translation to consult display form
- add debugging hooks and improved gender UI

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687fe573101c8329ae38a0eb035fe122