### PR TITLE
Fix conjugation translation lookup

### DIFF
--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -420,7 +420,7 @@ const loadWordTranslations = async () => {
       (ft) => ft.word_translation_id === selectedTranslationId
     )
 
-    const result = assignment?.word_translation?.translation || assignment?.translation || form.translation
+    const result = assignment?.translation || assignment?.word_translation?.translation || form.translation
     console.log('✅ Selected translation result:', result)
     return result
   }


### PR DESCRIPTION
## Summary
- correct translation lookup priority so conjugation translations display correctly

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_687ffff39acc832996d68fe5863345fb