### PR TITLE
Compact conjugation layout

### DIFF
--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -1093,35 +1093,36 @@ function ConjugationRow({
   const colors = getColors()
 
   return (
-    <div className="flex items-center py-2 px-3 rounded-md hover:bg-gray-50 even:bg-gray-50 even:hover:bg-gray-100 transition-colors min-h-12">
-      {/* Pronoun */}
-      <div className="w-16 flex-shrink-0 font-bold text-gray-600 text-lg">
-        {pronounDisplay}
-      </div>
-      
-      {/* Form */}
-      <div className={`w-32 flex-shrink-0 font-bold text-lg ${colors.form} flex items-center gap-1`}>
-        {form.form_text}
-        {isIrregular && <span className="text-amber-500 text-base">⚠️</span>}
-      </div>
+    <div className="py-2 px-3 rounded-md hover:bg-gray-50 even:bg-gray-50 even:hover:bg-gray-100 transition-colors">
+      <div className="flex items-center min-h-12">
+        {/* Pronoun */}
+        <div className="w-16 flex-shrink-0 font-bold text-gray-600 text-lg">
+          {pronounDisplay}
+        </div>
 
-      {/* Translation */}
-      <div className="flex-1 text-gray-600 text-lg mr-4 ml-4">
-        {form.translation}
+        {/* Form */}
+        <div className={`w-32 flex-shrink-0 font-bold text-lg ${colors.form} flex items-center gap-1`}>
+          {form.form_text}
+          {isIrregular && <span className="text-amber-500 text-base">⚠️</span>}
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-2 flex-shrink-0 ml-auto">
+          <AudioButton
+            wordId={form.id}
+            italianText={audioText}
+            audioFilename={form.audio_filename}
+            size="lg"
+            colorClass={colors.audio}
+          />
+          <button className="bg-emerald-600 text-white w-8 h-8 rounded flex items-center justify-center text-lg font-semibold hover:bg-emerald-700 transition-colors">
+            +
+          </button>
+        </div>
       </div>
-      
-      {/* Actions */}
-      <div className="flex items-center gap-2 flex-shrink-0">
-        <AudioButton
-          wordId={form.id}
-          italianText={audioText}
-          audioFilename={form.audio_filename}
-          size="lg"
-          colorClass={colors.audio}
-        />
-        <button className="bg-emerald-600 text-white w-8 h-8 rounded flex items-center justify-center text-lg font-semibold hover:bg-emerald-700 transition-colors">
-          +
-        </button>
+      {/* Translation */}
+      <div className="text-gray-600 text-lg ml-16 mt-1">
+        {form.translation}
       </div>
     </div>
   )

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -1093,17 +1093,17 @@ function ConjugationRow({
   const colors = getColors()
 
   return (
-    <div className="py-2 px-3 rounded-md hover:bg-gray-50 even:bg-gray-50 even:hover:bg-gray-100 transition-colors">
-      <div className="flex items-center min-h-12">
+    <div className="py-1 px-2 sm:py-2 sm:px-3 rounded-md hover:bg-gray-50 even:bg-gray-50 even:hover:bg-gray-100 transition-colors">
+      <div className="flex items-center min-h-10 sm:min-h-12">
         {/* Pronoun */}
-        <div className="w-16 flex-shrink-0 font-bold text-gray-600 text-lg">
+        <div className="w-12 sm:w-16 flex-shrink-0 font-bold text-gray-600 text-base sm:text-lg">
           {pronounDisplay}
         </div>
 
         {/* Form */}
-        <div className={`w-32 flex-shrink-0 font-bold text-lg ${colors.form} flex items-center gap-1`}>
+        <div className={`w-28 sm:w-32 flex-shrink-0 font-bold text-base sm:text-lg ${colors.form} flex items-center gap-1`}>
           {form.form_text}
-          {isIrregular && <span className="text-amber-500 text-base">⚠️</span>}
+          {isIrregular && <span className="text-amber-500 text-sm sm:text-base">⚠️</span>}
         </div>
 
         {/* Actions */}
@@ -1121,7 +1121,7 @@ function ConjugationRow({
         </div>
       </div>
       {/* Translation */}
-      <div className="text-gray-600 text-lg ml-16 mt-1">
+      <div className="text-gray-600 text-base sm:text-lg ml-12 sm:ml-16 mt-1">
         {form.translation}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- move translation under pronoun and form in `ConjugationModal`

## Testing
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68821dd00aa883299184f85316248212