### PR TITLE
Fix dropdown arrow design for additional translations

### DIFF
--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -465,8 +465,8 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
               onClick={() => setShowAdditionalMeanings(!showAdditionalMeanings)}
               className="text-sm text-gray-600 hover:text-gray-800 flex items-center gap-1"
             >
-              <span className={`transform transition-transform ${showAdditionalMeanings ? 'rotate-90' : ''}`}>
-                ▶
+              <span className={`transform transition-transform ${showAdditionalMeanings ? 'rotate-180' : ''}`}>
+                ▼
               </span>
               {additionalTranslations.length} additional meanings
             </button>


### PR DESCRIPTION
## Summary
- update WordCard additional translation toggle arrow to use the same chevron style as the conjugation screen

## Testing
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68825a8b23388329b533cfc95e94b42f