### PR TITLE
Add restriction indicators for translations

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -480,7 +480,15 @@ body {
 }
 
 .restriction-gender {
-  color: #7c3aed !important;
+  font-weight: bold;
+}
+
+.restriction-gender-male {
+  color: #3b82f6 !important;
+}
+
+.restriction-gender-female {
+  color: #ec4899 !important;
 }
 
 .restriction-plurality {
@@ -491,8 +499,12 @@ body {
   color: #dc2626 !important;
 }
 
-.restriction-gender:hover {
-  color: #6d28d9 !important;
+.restriction-gender-male:hover {
+  color: #1d4ed8 !important;
+}
+
+.restriction-gender-female:hover {
+  color: #be185d !important;
 }
 
 .restriction-plurality:hover {

--- a/app/globals.css
+++ b/app/globals.css
@@ -449,4 +449,58 @@ body {
   color: #f59e0b !important;
 }
 
+/* Story 10.5: Translation Restriction Indicators */
+.restriction-symbol-dropdown,
+.restriction-symbol-card {
+  font-weight: 500;
+  cursor: help;
+  transition: color 0.2s ease;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.restriction-symbol-dropdown {
+  font-size: 12px;
+  color: #6b7280;
+  margin-left: 4px;
+}
+
+.restriction-symbol-dropdown:hover {
+  color: #374151;
+}
+
+.restriction-symbol-card {
+  font-size: 14px;
+  color: #6b7280;
+  margin-left: 6px;
+}
+
+.restriction-symbol-card:hover {
+  color: #374151;
+}
+
+.restriction-gender {
+  color: #7c3aed !important;
+}
+
+.restriction-plurality {
+  color: #059669 !important;
+}
+
+.restriction-register {
+  color: #dc2626 !important;
+}
+
+.restriction-gender:hover {
+  color: #6d28d9 !important;
+}
+
+.restriction-plurality:hover {
+  color: #047857 !important;
+}
+
+.restriction-register:hover {
+  color: #b91c1c !important;
+}
+
 

--- a/components/TranslationSelector.js
+++ b/components/TranslationSelector.js
@@ -4,6 +4,7 @@
 // Compact dropdown with beautiful context tags
 
 import { useState, useRef, useEffect } from 'react'
+import { renderRestrictionIndicators } from '../lib/restriction-utils'
 
 export default function TranslationSelector({
   translations = [],
@@ -56,6 +57,11 @@ export default function TranslationSelector({
     }
 
     return tags
+  }
+
+  const getRestrictionIndicators = (translation) => {
+    const metadata = translation.context_metadata || {}
+    return renderRestrictionIndicators(metadata, 'restriction-symbol-dropdown')
   }
 
   return (
@@ -112,6 +118,15 @@ export default function TranslationSelector({
                       }`}>
                         {translation.translation}
                       </span>
+                      {getRestrictionIndicators(translation).map((indicator) => (
+                        <span
+                          key={indicator.key}
+                          className={indicator.className}
+                          title={indicator.title}
+                        >
+                          {indicator.symbol}
+                        </span>
+                      ))}
                       {isPrimary && (
                         <span className="text-xs bg-blue-500 text-white px-2 py-1 rounded-full font-medium flex-shrink-0">
                           Primary

--- a/components/TranslationSelector.js
+++ b/components/TranslationSelector.js
@@ -79,6 +79,16 @@ export default function TranslationSelector({
             <span className="text-teal-800 font-semibold truncate">
               {selectedTranslation?.translation || 'Select translation'}
             </span>
+            {selectedTranslation &&
+              getRestrictionIndicators(selectedTranslation).map((indicator) => (
+                <span
+                  key={indicator.key}
+                  className={indicator.className}
+                  title={indicator.title}
+                >
+                  {indicator.symbol}
+                </span>
+              ))}
             {selectedTranslation?.display_priority === 1 && (
               <span className="text-xs bg-blue-500 text-white px-2 py-1 rounded-full font-medium flex-shrink-0">
                 Primary

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -8,6 +8,7 @@ import { useState, useEffect } from 'react'
 import AudioButton from './AudioButton'
 import ConjugationModal from './ConjugationModal'
 import { checkPremiumAudio } from '../lib/audio-utils'
+import { renderRestrictionIndicators } from '../lib/restriction-utils'
 
 export default function WordCard({ word, onAddToDeck, className = '' }) {
   const [showForms, setShowForms] = useState(false)
@@ -307,6 +308,11 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     )
   }
 
+  const getRestrictionIndicators = (translation) => {
+    const metadata = translation.contextInfo || {}
+    return renderRestrictionIndicators(metadata, 'restriction-symbol-card')
+  }
+
   // Render verb-specific features
 
   return (
@@ -404,6 +410,15 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
                     <span className="text-base text-gray-900 font-medium">
                       {translation.translation}
                     </span>
+                    {getRestrictionIndicators(translation).map((indicator) => (
+                      <span
+                        key={indicator.key}
+                        className={indicator.className}
+                        title={indicator.title}
+                      >
+                        {indicator.symbol}
+                      </span>
+                    ))}
                   </div>
 
                   {/* Context Hint - Flexible space to push button right */}
@@ -489,6 +504,15 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
                         <span className="text-base text-gray-900 font-medium">
                           {translation.translation}
                         </span>
+                        {getRestrictionIndicators(translation).map((indicator) => (
+                          <span
+                            key={indicator.key}
+                            className={indicator.className}
+                            title={indicator.title}
+                          >
+                            {indicator.symbol}
+                          </span>
+                        ))}
                       </div>
                       <div className="flex-1 flex items-center justify-end mr-2">
                         <span className="text-xs text-gray-500 italic text-right">

--- a/lib/enhanced-dictionary-system.js
+++ b/lib/enhanced-dictionary-system.js
@@ -139,7 +139,8 @@ export class EnhancedDictionarySystem {
       semanticDomain: metadata.semantic_domain || null, // 'body-care', 'social-interaction'
       semanticType: metadata.semantic_type || null, // 'self-directed', 'mutual-action'
       appliesTo: metadata.applies_to || null, // 'objects-places-people', 'men'
-      genderSpecific: metadata.gender_specific || false
+      genderSpecific: metadata.gender_specific || false,
+      gender_usage: metadata.gender_usage || null
     };
   }
 

--- a/lib/restriction-utils.js
+++ b/lib/restriction-utils.js
@@ -18,6 +18,7 @@ export function parseRestrictions(contextMetadata) {
   if (contextMetadata.gender_usage === 'male-only') {
     restrictions.push({
       type: 'gender',
+      subtype: 'male',
       symbol: '♂',
       description: 'Use only with masculine subjects',
       severity: 'hard'
@@ -25,6 +26,7 @@ export function parseRestrictions(contextMetadata) {
   } else if (contextMetadata.gender_usage === 'female-only') {
     restrictions.push({
       type: 'gender',
+      subtype: 'female',
       symbol: '♀',
       description: 'Use only with feminine subjects',
       severity: 'hard'
@@ -111,14 +113,19 @@ export function getRestrictionDescription(contextMetadata) {
 export function renderRestrictionIndicators(contextMetadata, className = 'restriction-symbol') {
   const restrictions = parseRestrictions(contextMetadata)
 
-  return restrictions.map((restriction, index) => ({
-    key: `${restriction.type}-${index}`,
-    symbol: restriction.symbol,
-    description: restriction.description,
-    type: restriction.type,
-    className: `${className} restriction-${restriction.type}`,
-    title: restriction.description
-  }))
+  return restrictions.map((restriction, index) => {
+    const subtypeClass = restriction.subtype
+      ? ` restriction-${restriction.type}-${restriction.subtype}`
+      : ''
+    return {
+      key: `${restriction.type}-${index}`,
+      symbol: restriction.symbol,
+      description: restriction.description,
+      type: restriction.type,
+      className: `${className} restriction-${restriction.type}${subtypeClass}`,
+      title: restriction.description
+    }
+  })
 }
 
 /**
@@ -153,7 +160,23 @@ export const restrictionStyles = `
 
   /* Specific restriction type styling */
   .restriction-gender {
-    color: #7c3aed;
+    font-weight: bold;
+  }
+
+  .restriction-gender-male {
+    color: #3b82f6;
+  }
+
+  .restriction-gender-female {
+    color: #ec4899;
+  }
+
+  .restriction-gender-male:hover {
+    color: #1d4ed8;
+  }
+
+  .restriction-gender-female:hover {
+    color: #be185d;
   }
 
   .restriction-plurality {

--- a/lib/restriction-utils.js
+++ b/lib/restriction-utils.js
@@ -1,0 +1,216 @@
+// lib/restriction-utils.js
+// Utility functions for parsing and displaying translation restrictions
+// Story 10.5: Translation Context Indicators
+
+/**
+ * Parse context metadata to extract hard restrictions that need visual indicators
+ * @param {Object} contextMetadata - The context_metadata JSONB field from word_translations
+ * @returns {Array} Array of restriction objects with symbol and description
+ */
+export function parseRestrictions(contextMetadata) {
+  if (!contextMetadata || typeof contextMetadata !== 'object') {
+    return []
+  }
+
+  const restrictions = []
+
+  // Gender restrictions (HARD restrictions only)
+  if (contextMetadata.gender_usage === 'male-only') {
+    restrictions.push({
+      type: 'gender',
+      symbol: '♂',
+      description: 'Use only with masculine subjects',
+      severity: 'hard'
+    })
+  } else if (contextMetadata.gender_usage === 'female-only') {
+    restrictions.push({
+      type: 'gender',
+      symbol: '♀',
+      description: 'Use only with feminine subjects',
+      severity: 'hard'
+    })
+  }
+  // Note: 'female-preferred' is NOT a hard restriction, so no indicator
+
+  // Plurality restrictions (HARD restrictions only)
+  if (contextMetadata.plurality === 'plural-only') {
+    restrictions.push({
+      type: 'plurality',
+      symbol: '👥',
+      description: 'Use only with plural subjects',
+      severity: 'hard'
+    })
+  } else if (contextMetadata.plurality === 'singular-only') {
+    restrictions.push({
+      type: 'plurality',
+      symbol: '👤',
+      description: 'Use only with singular subjects',
+      severity: 'hard'
+    })
+  }
+
+  // Register restrictions (if we want to show formal restrictions)
+  // Currently commented out - uncomment if you want formal indicators
+  /*
+  if (contextMetadata.register === 'formal') {
+    restrictions.push({
+      type: 'register',
+      symbol: '👔',
+      description: 'Formal contexts only',
+      severity: 'soft'
+    })
+  }
+  */
+
+  return restrictions
+}
+
+/**
+ * Get restriction symbols as a simple array of strings
+ * @param {Object} contextMetadata - The context_metadata JSONB field
+ * @returns {Array} Array of Unicode symbol strings
+ */
+export function getRestrictionSymbols(contextMetadata) {
+  const restrictions = parseRestrictions(contextMetadata)
+  return restrictions.map((r) => r.symbol)
+}
+
+/**
+ * Check if a translation has any hard restrictions
+ * @param {Object} contextMetadata - The context_metadata JSONB field
+ * @returns {boolean} True if translation has restrictions requiring indicators
+ */
+export function hasRestrictions(contextMetadata) {
+  const restrictions = parseRestrictions(contextMetadata)
+  return restrictions.length > 0
+}
+
+/**
+ * Get a readable description of all restrictions for a translation
+ * @param {Object} contextMetadata - The context_metadata JSONB field
+ * @returns {string} Human-readable restriction summary
+ */
+export function getRestrictionDescription(contextMetadata) {
+  const restrictions = parseRestrictions(contextMetadata)
+
+  if (restrictions.length === 0) {
+    return 'No usage restrictions'
+  }
+
+  const descriptions = restrictions.map((r) => r.description)
+  return descriptions.join(', ')
+}
+
+/**
+ * Render restriction indicators as React/HTML elements
+ * For use in React components - returns JSX-compatible structure
+ * @param {Object} contextMetadata - The context_metadata JSONB field
+ * @param {string} className - Optional CSS class for styling
+ * @returns {Array} Array of restriction indicator objects for rendering
+ */
+export function renderRestrictionIndicators(contextMetadata, className = 'restriction-symbol') {
+  const restrictions = parseRestrictions(contextMetadata)
+
+  return restrictions.map((restriction, index) => ({
+    key: `${restriction.type}-${index}`,
+    symbol: restriction.symbol,
+    description: restriction.description,
+    type: restriction.type,
+    className: `${className} restriction-${restriction.type}`,
+    title: restriction.description
+  }))
+}
+
+/**
+ * Check if a specific restriction type exists
+ * @param {Object} contextMetadata - The context_metadata JSONB field
+ * @param {string} restrictionType - Type to check ('gender', 'plurality', 'register')
+ * @returns {boolean} True if restriction type exists
+ */
+export function hasRestrictionType(contextMetadata, restrictionType) {
+  const restrictions = parseRestrictions(contextMetadata)
+  return restrictions.some((r) => r.type === restrictionType)
+}
+
+/**
+ * CSS classes for styling restriction symbols
+ * Import this into your globals.css or component styles
+ */
+export const restrictionStyles = `
+  /* Restriction symbol styling */
+  .restriction-symbol {
+    font-size: 14px;
+    color: #6b7280;
+    margin-left: 6px;
+    font-weight: 500;
+    cursor: help;
+    transition: color 0.2s ease;
+  }
+
+  .restriction-symbol:hover {
+    color: #374151;
+  }
+
+  /* Specific restriction type styling */
+  .restriction-gender {
+    color: #7c3aed;
+  }
+
+  .restriction-plurality {
+    color: #059669;
+  }
+
+  .restriction-register {
+    color: #dc2626;
+  }
+
+  /* Different contexts */
+  .restriction-symbol-dropdown {
+    font-size: 12px;
+    margin-left: 4px;
+  }
+
+  .restriction-symbol-card {
+    font-size: 14px;
+    margin-left: 8px;
+  }
+`
+
+// Example usage patterns for documentation:
+/*
+
+// Basic usage in a component:
+import { parseRestrictions, getRestrictionSymbols } from './restriction-utils'
+
+const translation = {
+  translation: 'handsome',
+  context_metadata: {
+    gender_usage: 'male-only',
+    register: 'neutral'
+  }
+}
+
+const restrictions = parseRestrictions(translation.context_metadata)
+// Returns: [{ type: 'gender', symbol: '♂', description: 'Use only with masculine subjects', severity: 'hard' }]
+
+const symbols = getRestrictionSymbols(translation.context_metadata)
+// Returns: ['♂']
+
+// In React component:
+const indicators = renderRestrictionIndicators(translation.context_metadata)
+return (
+  <div>
+    {translation.translation}
+    {indicators.map(indicator => (
+      <span
+        key={indicator.key}
+        className={indicator.className}
+        title={indicator.title}
+      >
+        {indicator.symbol}
+      </span>
+    ))}
+  </div>
+)
+
+*/


### PR DESCRIPTION
## Summary
- add new `restriction-utils` helper for parsing restriction metadata
- display restriction symbols in `TranslationSelector`
- show restriction symbols in `WordCard`
- style restriction symbols in `globals.css`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883bfce81b08329a3b274fe92fce26c