### PR TITLE
Verb color tweaks with conjugation tags

### DIFF
--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -9,6 +9,7 @@ import AudioButton from './AudioButton'
 import SectionHeading from './SectionHeading'
 import { VariantCalculator } from '../lib/variant-calculator'
 import TranslationSelector from './TranslationSelector'
+import { getConjugationColors } from '../lib/conjugation-colors'
 
 // Desired display order for moods and tenses
 const moodOrder = [
@@ -86,6 +87,68 @@ export default function ConjugationModal({
 
   // Quick scratch/erase animation state to fade forms out and back in
   const [isContentChanging, setIsContentChanging] = useState(false)
+
+  const conjugationColors = getConjugationColors(word?.tags || [])
+
+  const getConjugationType = (tags) => {
+    if (tags?.includes('are-conjugation')) return '-are'
+    if (tags?.includes('ere-conjugation')) return '-ere'
+    if (tags?.includes('ire-isc-conjugation')) return window.innerWidth < 768 ? '-isc' : '-isc'
+    if (tags?.includes('ire-conjugation')) return '-ire'
+    return '-are'
+  }
+
+  const getAuxiliaryTag = (tags) => {
+    const isMobile = window.innerWidth < 768
+    if (tags?.includes('avere-auxiliary')) {
+      return (
+        <span className="border border-gray-300 text-gray-700 px-3 py-1 rounded-full text-sm">
+          {isMobile ? 'ave' : 'avere'}
+        </span>
+      )
+    }
+    if (tags?.includes('essere-auxiliary')) {
+      return (
+        <span className="border border-gray-300 text-gray-700 px-3 py-1 rounded-full text-sm">
+          {isMobile ? 'ess' : 'essere'}
+        </span>
+      )
+    }
+    if (tags?.includes('both-auxiliary')) {
+      return (
+        <span className="border border-gray-300 text-gray-700 px-3 py-1 rounded-full text-sm">
+          {isMobile ? 'both' : 'both'}
+        </span>
+      )
+    }
+    return null
+  }
+
+  const getTransitivityTag = (tags) => {
+    const isMobile = window.innerWidth < 768
+    if (tags?.includes('transitive-verb')) {
+      return (
+        <span className="border border-gray-300 text-gray-700 px-3 py-1 rounded-full text-sm">
+          {isMobile ? 'tr' : 'transitive'}
+        </span>
+      )
+    }
+    if (tags?.includes('intransitive-verb')) {
+      return (
+        <span className="border border-gray-300 text-gray-700 px-3 py-1 rounded-full text-sm">
+          {isMobile ? 'intr' : 'intransitive'}
+        </span>
+      )
+    }
+    if (tags?.includes('both-transitivity')) {
+      return (
+        <span className="border border-gray-300 text-gray-700 px-3 py-1 rounded-full text-sm">
+          {isMobile ? 'both' : 'both'}
+        </span>
+      )
+    }
+    return null
+  }
 
   // Extract tag values from tag array
   const extractTagValue = (tags, category) => {
@@ -812,36 +875,51 @@ const loadWordTranslations = async () => {
       >
         <div className="flex flex-col h-full">
           {/* Header */}
-          <div className="flex items-center justify-between p-4 border-b bg-gradient-to-br from-teal-500 to-cyan-600">
+          <div
+            className="flex items-center justify-between p-4 border-b"
+            style={{ background: `linear-gradient(to right, ${conjugationColors.primary}, #14b8a6)` }}
+          >
             <div className="flex items-center gap-2">
               <h2 className="text-lg font-semibold text-white">
-                📝 Conjugations: {word?.italian}
+                Conjugations: {word?.italian}
               </h2>
-              {/* Word Tags */}
-              <div className="flex gap-1 ml-2">
-                {word?.tags?.includes('are-conjugation') && (
-                  <span className="text-sm bg-white bg-opacity-20 text-white px-2 py-1 rounded-full font-semibold">
-                    🔸 -are
-                  </span>
-                )}
-                {word?.tags?.includes('avere-auxiliary') && (
-                  <span className="text-sm bg-white bg-opacity-20 text-white px-2 py-1 rounded-full font-semibold">
-                    🤝 avere
-                  </span>
-                )}
-                {word?.tags?.includes('transitive-verb') && (
-                  <span className="text-sm bg-white bg-opacity-20 text-white px-2 py-1 rounded-full font-semibold">
-                    ➡️ trans
-                  </span>
-                )}
-              </div>
             </div>
-            <button 
-              onClick={onClose}
-              className="text-white hover:text-cyan-200 text-xl transition-colors duration-200"
-            >
+            <button onClick={onClose} className="text-white hover:text-cyan-200 text-xl">
               ✕
             </button>
+          </div>
+
+          {/* New Tags Section */}
+          <div className="p-3 border-b bg-gray-50">
+            <div className="flex flex-wrap gap-2">
+              {/* Conjugation Type Tag */}
+              <span
+                className="px-3 py-1 rounded-full text-white font-semibold text-sm"
+                style={{ backgroundColor: conjugationColors.primary }}
+              >
+                {getConjugationType(word?.tags)}
+              </span>
+
+              {/* Irregularity */}
+              {word?.tags?.includes('irregular-pattern') && (
+                <span className="bg-red-500 text-white px-3 py-1 rounded-full text-sm font-semibold">
+                  {window.innerWidth < 768 ? '⚠️' : '⚠️ IRREG'}
+                </span>
+              )}
+
+              {/* Auxiliary */}
+              {getAuxiliaryTag(word?.tags)}
+
+              {/* Reflexive */}
+              {word?.tags?.includes('reflexive-verb') && (
+                <span className="border border-gray-300 text-gray-700 px-3 py-1 rounded-full text-sm">
+                  {window.innerWidth < 768 ? 'refl' : 'reflexive'}
+                </span>
+              )}
+
+              {/* Transitivity */}
+              {getTransitivityTag(word?.tags)}
+            </div>
           </div>
 
           {/* Controls */}
@@ -1176,7 +1254,7 @@ function ConjugationRow({
             italianText={audioText}
             audioFilename={form.audio_filename}
             size="lg"
-            colorClass={colors.audio}
+            colorClass={conjugationColors.primary}
           />
           <button className="bg-emerald-600 text-white w-8 h-8 rounded flex items-center justify-center text-lg font-semibold hover:bg-emerald-700 transition-all duration-200 hover:shadow-md active:transform active:scale-95">
             +

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -9,6 +9,7 @@ import AudioButton from './AudioButton'
 import ConjugationModal from './ConjugationModal'
 import { checkPremiumAudio } from '../lib/audio-utils'
 import { renderRestrictionIndicators } from '../lib/restriction-utils'
+import { getConjugationColors } from '../lib/conjugation-colors'
 
 export default function WordCard({ word, onAddToDeck, className = '' }) {
   const [showForms, setShowForms] = useState(false)
@@ -131,9 +132,24 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       regional: { display: '🗺️ REG', class: 'bg-green-500 text-white', essential: true, description: 'Regional dialects and variants' },
 
       // SECONDARY TAGS - Detailed grammatical information
-      'are-conjugation': { display: '🔸 -are', class: 'bg-gray-200 text-gray-700', essential: false, description: 'First conjugation group' },
-      'ere-conjugation': { display: '🔹 -ere', class: 'bg-gray-200 text-gray-700', essential: false, description: 'Second conjugation group' },
-      'ire-conjugation': { display: '🔶 -ire', class: 'bg-gray-200 text-gray-700', essential: false, description: 'Third conjugation group' },
+      'are-conjugation': { 
+        display: '🔸 -are', 
+        class: 'bg-gray-200 text-gray-700', 
+        essential: false, 
+        description: 'First conjugation group' 
+      },
+      'ere-conjugation': { 
+        display: '🔹 -ere', 
+        class: 'bg-gray-200 text-gray-700', 
+        essential: false, 
+        description: 'Second conjugation group' 
+      },
+      'ire-conjugation': { 
+        display: '🔶 -ire', 
+        class: 'bg-gray-200 text-gray-700', 
+        essential: false, 
+        description: 'Third conjugation group' 
+      },
 
       // Auxiliary Verbs (detailed)
       'avere-auxiliary': { display: '🤝 avere', class: 'bg-gray-200 text-gray-700', essential: false, description: 'Uses avere in compound tenses' },
@@ -250,6 +266,22 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       'bg-gray-200 text-gray-700': 'border bg-transparent text-gray-700 border-gray-400'
     }
     return map[cls] || cls
+  }
+
+  const getConjugationTagColor = (tagKey, wordTags, originalClass) => {
+    if (wordTags?.includes('are-conjugation') && tagKey === 'are-conjugation') {
+      return 'border bg-transparent text-teal-600 border-teal-600'
+    }
+    if (wordTags?.includes('ere-conjugation') && tagKey === 'ere-conjugation') {
+      return 'border bg-transparent text-cyan-500 border-cyan-500'
+    }
+    if (
+      (wordTags?.includes('ire-conjugation') || wordTags?.includes('ire-isc-conjugation')) &&
+      (tagKey === 'ire-conjugation' || tagKey === 'ire-isc-conjugation')
+    ) {
+      return 'border bg-transparent text-teal-400 border-teal-400'
+    }
+    return outlinedClass(originalClass)
   }
 
   // Extract gender and irregularity tags for header
@@ -545,7 +577,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             {bottomTags.map((tag, index) => (
               <span
                 key={index}
-                className={`tag-detailed text-xs px-2 py-1 rounded-full font-semibold ${outlinedClass(tag.class)}`}
+                className={`tag-detailed text-xs px-2 py-1 rounded-full font-semibold ${getConjugationTagColor(tag.tag, word.tags, tag.class)}`}
                 title={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}

--- a/lib/conjugation-colors.js
+++ b/lib/conjugation-colors.js
@@ -1,0 +1,40 @@
+export const getConjugationColors = (wordTags) => {
+  if (wordTags?.includes('are-conjugation')) {
+    return {
+      type: 'are',
+      primary: '#14b8a6',
+      light: '#f0fdfa',
+      border: '#5eead4',
+      text: '#134e4a'
+    }
+  }
+
+  if (wordTags?.includes('ere-conjugation')) {
+    return {
+      type: 'ere',
+      primary: '#06b6d4',
+      light: '#ecfeff',
+      border: '#67e8f9',
+      text: '#164e63'
+    }
+  }
+
+  if (wordTags?.includes('ire-conjugation') || wordTags?.includes('ire-isc-conjugation')) {
+    return {
+      type: 'ire',
+      primary: '#2dd4bf',
+      light: '#f0fdfa',
+      border: '#99f6e4',
+      text: '#134e4a'
+    }
+  }
+
+  // Default fallback
+  return {
+    type: 'default',
+    primary: '#14b8a6',
+    light: '#f0fdfa',
+    border: '#5eead4',
+    text: '#134e4a'
+  }
+}


### PR DESCRIPTION
## Summary
- introduce utility for conjugation color mapping
- colorize ConjugationModal header and add tag badges
- tint audio button in ConjugationModal
- show conjugation-tag colors on WordCard badges

## Testing
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6884bd20b40883299fff020cd960f74a