### PR TITLE
Increase width of ConjugationModal on tablet screens

### DIFF
--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -877,7 +877,7 @@ const loadWordTranslations = async () => {
       <div 
         className={`
           fixed inset-y-0 right-0 bg-white shadow-xl z-50
-          w-full md:w-3/4 lg:w-2/3 xl:w-1/2 max-w-4xl
+          w-full md:w-11/12 lg:w-2/3 xl:w-1/2 max-w-4xl
           transition-transform duration-300 ease-in-out
           ${isOpen ? 'transform translate-x-0' : 'transform translate-x-full'}
         `}

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -877,7 +877,7 @@ const loadWordTranslations = async () => {
       <div 
         className={`
           fixed inset-y-0 right-0 bg-white shadow-xl z-50
-          w-full md:w-11/12 lg:w-2/3 xl:w-1/2 max-w-4xl
+          w-full md:w-11/12 lg:w-11/12 xl:w-1/2 max-w-4xl
           transition-transform duration-300 ease-in-out
           ${isOpen ? 'transform translate-x-0' : 'transform translate-x-full'}
         `}


### PR DESCRIPTION
## Summary
- enlarge tablet width of the conjugation modal

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885729855648329ba04b3407d990e14