### PR TITLE
Support new conjugation forms

### DIFF
--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -306,10 +306,7 @@ const loadWordTranslations = async () => {
             .split(' ')
             .map(word => word.charAt(0).toUpperCase() + word.slice(1))
             .join(' '),
-          displayTense:
-            ['indicativo-negativo', 'imperativo-negativo'].includes(mood)
-              ? `${baseDisplayTense} (Neg.)`
-              : baseDisplayTense
+          displayTense: baseDisplayTense
         })
       })
     })

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -25,29 +25,29 @@ const moodOrder = [
 const tenseOrderMap = {
   indicativo: [
     'presente',
-    'passato-prossimo',
-    'imperfetto',
-    'trapassato-prossimo',
     'presente-progressivo',
+    'imperfetto',
     'passato-progressivo',
+    'passato-prossimo',
+    'trapassato-prossimo',
     'passato-remoto',
     'trapassato-remoto',
     'futuro-semplice',
-    'futuro-anteriore',
-    'futuro-progressivo'
+    'futuro-progressivo',
+    'futuro-anteriore'
   ],
   'indicativo-negativo': [
     'presente',
-    'passato-prossimo',
-    'imperfetto',
-    'trapassato-prossimo',
     'presente-progressivo',
+    'imperfetto',
     'passato-progressivo',
+    'passato-prossimo',
+    'trapassato-prossimo',
     'passato-remoto',
     'trapassato-remoto',
     'futuro-semplice',
-    'futuro-anteriore',
-    'futuro-progressivo'
+    'futuro-progressivo',
+    'futuro-anteriore'
   ],
   congiuntivo: [
     'congiuntivo-presente',
@@ -277,6 +277,12 @@ const loadWordTranslations = async () => {
         if (hasIrregular && hasRegular) regularity = '🔄'
         else if (hasIrregular) regularity = '⚠️'
         
+        const baseDisplayTense = tense
+          .replace('-', ' ')
+          .split(' ')
+          .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+          .join(' ')
+
         options.push({
           mood,
           tense,
@@ -287,9 +293,10 @@ const loadWordTranslations = async () => {
             .split(' ')
             .map(word => word.charAt(0).toUpperCase() + word.slice(1))
             .join(' '),
-          displayTense: tense.replace('-', ' ').split(' ').map(word => 
-            word.charAt(0).toUpperCase() + word.slice(1)
-          ).join(' ')
+          displayTense:
+            mood === 'indicativo-negativo'
+              ? `${baseDisplayTense} (Neg.)`
+              : baseDisplayTense
         })
       })
     })

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -17,7 +17,6 @@ const moodOrder = [
   'congiuntivo',
   'condizionale',
   'imperativo',
-  'imperativo-negativo',
   'infinito',
   'participio',
   'gerundio'
@@ -60,8 +59,7 @@ const tenseOrderMap = {
     'condizionale-presente',
     'condizionale-passato'
   ],
-  imperativo: ['imperativo-presente'],
-  'imperativo-negativo': ['imperativo-negativo'],
+  imperativo: ['imperativo-presente', 'imperativo-negativo'],
   infinito: ['infinito-presente', 'infinito-passato'],
   participio: ['participio-presente', 'participio-passato'],
   gerundio: ['gerundio-presente', 'gerundio-passato']
@@ -115,7 +113,6 @@ export default function ConjugationModal({
         'congiuntivo',
         'condizionale',
         'imperativo',
-        'imperativo-negativo',
         'infinito',
         'participio',
         'gerundio'

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -17,6 +17,7 @@ const moodOrder = [
   'congiuntivo',
   'condizionale',
   'imperativo',
+  'imperativo-negativo',
   'infinito',
   'participio',
   'gerundio'
@@ -60,6 +61,7 @@ const tenseOrderMap = {
     'condizionale-passato'
   ],
   imperativo: ['imperativo-presente'],
+  'imperativo-negativo': ['imperativo-negativo'],
   infinito: ['infinito-presente', 'infinito-passato'],
   participio: ['participio-presente', 'participio-passato'],
   gerundio: ['gerundio-presente', 'gerundio-passato']
@@ -107,7 +109,17 @@ export default function ConjugationModal({
     if (!tags || !Array.isArray(tags)) return null
     
     if (category === 'mood') {
-      const moodTags = ['indicativo', 'indicativo-negativo', 'congiuntivo', 'condizionale', 'imperativo', 'infinito', 'participio', 'gerundio']
+      const moodTags = [
+        'indicativo',
+        'indicativo-negativo',
+        'congiuntivo',
+        'condizionale',
+        'imperativo',
+        'imperativo-negativo',
+        'infinito',
+        'participio',
+        'gerundio'
+      ]
       return tags.find(tag => moodTags.includes(tag)) || null
     }
     
@@ -131,6 +143,7 @@ export default function ConjugationModal({
         'condizionale-presente',
         'condizionale-passato',
         'imperativo-presente',
+        'imperativo-negativo',
         'infinito-presente',
         'infinito-passato',
         'participio-presente',
@@ -294,7 +307,7 @@ const loadWordTranslations = async () => {
             .map(word => word.charAt(0).toUpperCase() + word.slice(1))
             .join(' '),
           displayTense:
-            mood === 'indicativo-negativo'
+            ['indicativo-negativo', 'imperativo-negativo'].includes(mood)
               ? `${baseDisplayTense} (Neg.)`
               : baseDisplayTense
         })

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -13,6 +13,7 @@ import TranslationSelector from './TranslationSelector'
 // Desired display order for moods and tenses
 const moodOrder = [
   'indicativo',
+  'indicativo-negativo',
   'congiuntivo',
   'condizionale',
   'imperativo',
@@ -32,7 +33,21 @@ const tenseOrderMap = {
     'passato-remoto',
     'trapassato-remoto',
     'futuro-semplice',
-    'futuro-anteriore'
+    'futuro-anteriore',
+    'futuro-progressivo'
+  ],
+  'indicativo-negativo': [
+    'presente',
+    'passato-prossimo',
+    'imperfetto',
+    'trapassato-prossimo',
+    'presente-progressivo',
+    'passato-progressivo',
+    'passato-remoto',
+    'trapassato-remoto',
+    'futuro-semplice',
+    'futuro-anteriore',
+    'futuro-progressivo'
   ],
   congiuntivo: [
     'congiuntivo-presente',
@@ -92,7 +107,7 @@ export default function ConjugationModal({
     if (!tags || !Array.isArray(tags)) return null
     
     if (category === 'mood') {
-      const moodTags = ['indicativo', 'congiuntivo', 'condizionale', 'imperativo', 'infinito', 'participio', 'gerundio']
+      const moodTags = ['indicativo', 'indicativo-negativo', 'congiuntivo', 'condizionale', 'imperativo', 'infinito', 'participio', 'gerundio']
       return tags.find(tag => moodTags.includes(tag)) || null
     }
     
@@ -108,6 +123,7 @@ export default function ConjugationModal({
         'trapassato-remoto',
         'futuro-semplice',
         'futuro-anteriore',
+        'futuro-progressivo',
         'congiuntivo-presente',
         'congiuntivo-passato',
         'congiuntivo-imperfetto',
@@ -266,7 +282,11 @@ const loadWordTranslations = async () => {
           tense,
           regularity,
           count: forms.length,
-          displayMood: mood.charAt(0).toUpperCase() + mood.slice(1),
+          displayMood: mood
+            .replace('-', ' ')
+            .split(' ')
+            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' '),
           displayTense: tense.replace('-', ' ').split(' ').map(word => 
             word.charAt(0).toUpperCase() + word.slice(1)
           ).join(' ')
@@ -380,10 +400,12 @@ const loadWordTranslations = async () => {
   // Check if compound tense
   const isCompoundTense = () => {
     const currentForms = getCurrentForms()
-    return currentForms.some(form =>
-      form.tags?.includes('compound') &&
-      !form.tags?.includes('presente-progressivo') &&
-      !form.tags?.includes('passato-progressivo')
+    return currentForms.some(
+      form =>
+        form.tags?.includes('compound') &&
+        !form.tags?.includes('presente-progressivo') &&
+        !form.tags?.includes('passato-progressivo') &&
+        !form.tags?.includes('futuro-progressivo')
     )
   }
 
@@ -401,7 +423,8 @@ const loadWordTranslations = async () => {
         word?.tags?.includes('essere-auxiliary') &&
         form.tags?.includes('compound') &&
         !form.tags?.includes('presente-progressivo') &&
-        !form.tags?.includes('passato-progressivo')
+        !form.tags?.includes('passato-progressivo') &&
+        !form.tags?.includes('futuro-progressivo')
 
       // Pronoun changes matter for ANY verb when audio includes pronouns
       const pronounChanges =
@@ -443,7 +466,8 @@ const loadWordTranslations = async () => {
         word?.tags?.includes('essere-auxiliary') &&
         form.tags?.includes('compound') &&
         !form.tags?.includes('presente-progressivo') &&
-        !form.tags?.includes('passato-progressivo')
+        !form.tags?.includes('passato-progressivo') &&
+        !form.tags?.includes('futuro-progressivo')
 
       if (audioPreference === 'form-only') {
         // Form-only mode: show lui/lei for forms without gender variants
@@ -506,7 +530,8 @@ const loadWordTranslations = async () => {
       word?.tags?.includes('essere-auxiliary') &&
       displayForm.tags?.includes('compound') &&
       !displayForm.tags?.includes('presente-progressivo') &&
-      !displayForm.tags?.includes('passato-progressivo')
+      !displayForm.tags?.includes('passato-progressivo') &&
+      !displayForm.tags?.includes('futuro-progressivo')
 
     if (audioPreference === 'form-only' && !hasGenderVariants) {
       console.log('📝 Form-only mode, no gender variants:', translation)
@@ -1135,6 +1160,7 @@ function ConjugationRow({
       form.tags?.includes('compound') &&
       !form.tags?.includes('presente-progressivo') &&
       !form.tags?.includes('passato-progressivo') &&
+      !form.tags?.includes('futuro-progressivo') &&
       (wordTags?.includes('essere-auxiliary') || form.base_form_id)
 
     // Check if this is a 3rd person form that changes pronouns

--- a/documentation/tagging and db design.md
+++ b/documentation/tagging and db design.md
@@ -182,9 +182,7 @@ These tags capture the specific grammatical properties of individual conjugated 
 
 **Imperative Mood System** - Command and instruction forms
 - `imperativo-presente` (14 forms) - Present imperative (parla!, parlate!)
-
-**Negative Imperative System** - Commands in the negative
-- `imperativo-negativo` forms like "non parlare" for "don't speak"
+- `imperativo-negativo` (14 forms) - Negative imperative (non parlare)
 
 **Negative Indicative System** - Negated versions of indicative tenses
 - `indicativo-negativo` forms include "non" before the verb across all tenses
@@ -407,7 +405,7 @@ CREATE TABLE word_forms (
   -- Mood validation for verb forms
   CONSTRAINT valid_form_mood CHECK (form_mood IS NULL OR form_mood IN (
     'indicativo', 'indicativo-negativo', 'congiuntivo', 'condizionale', 'imperativo',
-    'imperativo-negativo', 'infinito', 'participio', 'gerundio'
+    'infinito', 'participio', 'gerundio'
   )),
   
   -- Tense validation

--- a/documentation/tagging and db design.md
+++ b/documentation/tagging and db design.md
@@ -183,6 +183,9 @@ These tags capture the specific grammatical properties of individual conjugated 
 **Imperative Mood System** - Command and instruction forms
 - `imperativo-presente` (14 forms) - Present imperative (parla!, parlate!)
 
+**Negative Imperative System** - Commands in the negative
+- `imperativo-negativo` forms like "non parlare" for "don't speak"
+
 **Negative Indicative System** - Negated versions of indicative tenses
 - `indicativo-negativo` forms include "non" before the verb across all tenses
 
@@ -404,7 +407,7 @@ CREATE TABLE word_forms (
   -- Mood validation for verb forms
   CONSTRAINT valid_form_mood CHECK (form_mood IS NULL OR form_mood IN (
     'indicativo', 'indicativo-negativo', 'congiuntivo', 'condizionale', 'imperativo',
-    'infinito', 'participio', 'gerundio'
+    'imperativo-negativo', 'infinito', 'participio', 'gerundio'
   )),
   
   -- Tense validation
@@ -413,7 +416,8 @@ CREATE TABLE word_forms (
     'trapassato-prossimo', 'trapassato-remoto', 'futuro-semplice', 'futuro-anteriore',
     'congiuntivo-presente', 'congiuntivo-imperfetto', 'congiuntivo-passato', 'congiuntivo-trapassato',
     'condizionale-presente', 'condizionale-passato', 'imperativo-presente',
-    'infinito-presente', 'infinito-passato', 'participio-presente', 'participio-passato',
+    'imperativo-negativo', 'infinito-presente', 'infinito-passato',
+    'participio-presente', 'participio-passato',
     'gerundio-presente', 'gerundio-passato', 'futuro-progressivo'
   )),
   

--- a/documentation/tagging and db design.md
+++ b/documentation/tagging and db design.md
@@ -168,6 +168,7 @@ These tags capture the specific grammatical properties of individual conjugated 
 **Future Tense System** - Simple and compound future expressions
 - `futuro-semplice` (18 forms) - Simple future (parlerò, andrò)
 - `futuro-anteriore` (18 forms) - Future perfect (avrò parlato)
+- `futuro-progressivo` (18 forms) - Future continuous (starò parlando)
 
 **Subjunctive Mood System** - Subjective and hypothetical expressions
 - `congiuntivo-presente` (18 forms) - Present subjunctive (che io parli)
@@ -181,6 +182,9 @@ These tags capture the specific grammatical properties of individual conjugated 
 
 **Imperative Mood System** - Command and instruction forms
 - `imperativo-presente` (14 forms) - Present imperative (parla!, parlate!)
+
+**Negative Indicative System** - Negated versions of indicative tenses
+- `indicativo-negativo` forms include "non" before the verb across all tenses
 
 **Non-Finite Forms** - Verbal forms without person/number specification
 - `infinito-presente` (3 forms) - Present infinitive (parlare, andare)
@@ -399,7 +403,7 @@ CREATE TABLE word_forms (
   
   -- Mood validation for verb forms
   CONSTRAINT valid_form_mood CHECK (form_mood IS NULL OR form_mood IN (
-    'indicativo', 'congiuntivo', 'condizionale', 'imperativo', 
+    'indicativo', 'indicativo-negativo', 'congiuntivo', 'condizionale', 'imperativo',
     'infinito', 'participio', 'gerundio'
   )),
   
@@ -410,7 +414,7 @@ CREATE TABLE word_forms (
     'congiuntivo-presente', 'congiuntivo-imperfetto', 'congiuntivo-passato', 'congiuntivo-trapassato',
     'condizionale-presente', 'condizionale-passato', 'imperativo-presente',
     'infinito-presente', 'infinito-passato', 'participio-presente', 'participio-passato',
-    'gerundio-presente', 'gerundio-passato'
+    'gerundio-presente', 'gerundio-passato', 'futuro-progressivo'
   )),
   
   -- Person validation

--- a/lib/variant-calculator.js
+++ b/lib/variant-calculator.js
@@ -13,8 +13,12 @@ export class VariantCalculator {
     if (!formTags.includes('compound')) return null;
 
     // PROGRESSIVE forms use gerunds, so they never get gender variants
-    if (formTags.includes('presente-progressivo') ||
-        formTags.includes('passato-progressivo')) return null;
+    if (
+      formTags.includes('presente-progressivo') ||
+      formTags.includes('passato-progressivo') ||
+      formTags.includes('futuro-progressivo')
+    )
+      return null;
 
     // INCLUDE compound forms that use past participles:
     // - Passato prossimo: "sono andato" → "sono andata" ✅


### PR DESCRIPTION
## Summary
- handle negative mood and new progressive tense
- recognize new mood/tense in display and grouping
- document database updates for new forms
- ensure variant calculator ignores new progressive tense

## Testing
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68860a1546a0832982c63a7b4b8e962b