### PR TITLE
Fix gender fallback for translations

### DIFF
--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -558,12 +558,22 @@ const loadWordTranslations = async () => {
           .replace(/^He\/she\b/, 'He')
           .replace(/\bhimself\/herself\b/gi, 'himself')
           .replace(/^Himself\/herself\b/, 'Himself')
+          // Fallback when translation doesn't use he/she placeholders
+          .replace(/\b[Ss]he\b/g, match =>
+            match === 'She' ? 'He' : 'he'
+          )
+          .replace(/\bherself\b/gi, 'himself')
       } else {
         translation = translation
           .replace(/\bhe\/she\b/gi, 'she')
           .replace(/^He\/she\b/, 'She')
           .replace(/\bhimself\/herself\b/gi, 'herself')
           .replace(/^Himself\/herself\b/, 'Herself')
+          // Fallback when translation doesn't use he/she placeholders
+          .replace(/\b[Hh]e\b/g, match =>
+            match === 'He' ? 'She' : 'she'
+          )
+          .replace(/\bhimself\b/gi, 'herself')
       }
       console.log('✨ Final gendered translation:', translation)
     }


### PR DESCRIPTION
## Summary
- handle translations missing he/she placeholders

## Testing
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6886439d33bc832992aab2e91a417610