### PR TITLE
Add dynamic auxiliary conjugation

### DIFF
--- a/app/debug/page.js
+++ b/app/debug/page.js
@@ -527,20 +527,7 @@ export default function DebugPage() {
           </div>
         </div>
 
-        {/* Instructions */}
-        <div className="mt-6 bg-blue-50 border border-blue-200 rounded-lg p-4">
-          <h3 className="text-lg font-semibold text-blue-800 mb-2">📋 What This Will Show</h3>
-          <div className="text-sm text-blue-700 space-y-2">
-            <p><strong>Expected for "finire":</strong></p>
-            <ul className="list-disc list-inside space-y-1 ml-4">
-              <li>2 translations loaded (one with avere, one with essere)</li>
-              <li>Participle "finito" found with correct tags</li>
-              <li>Auxiliary lookup working for selected translation</li>
-              <li>Compound forms generated (like "ho finito")</li>
-            </ul>
-            <p className="mt-2"><strong>If something's wrong:</strong> The debug logs will show exactly where it breaks.</p>
-          </div>
-        </div>
+
       </div>
     </div>
   )

--- a/app/debug/page.js
+++ b/app/debug/page.js
@@ -1,0 +1,486 @@
+'use client'
+
+// app/debug/page.js
+// Auxiliary System Debugger - Uses Real Supabase Data
+
+import { useState, useEffect } from 'react'
+import { supabase } from '../../lib/supabase'
+import { EnhancedDictionarySystem } from '../../lib/enhanced-dictionary-system'
+import { AuxiliaryPatternService } from '../../lib/auxiliary-pattern-service'
+
+export default function DebugPage() {
+  const [debugData, setDebugData] = useState({
+    word: null,
+    translations: [],
+    selectedTranslationId: null,
+    auxiliaryLookup: null,
+    storedForms: [],
+    buildingBlocks: {
+      participle: null,
+      gerund: null
+    },
+    auxiliaryPatterns: [],
+    generatedCompounds: [],
+    errors: [],
+    logs: []
+  })
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [dictionarySystem] = useState(() => new EnhancedDictionarySystem(supabase))
+  const [auxiliaryService] = useState(() => new AuxiliaryPatternService(supabase))
+
+  // Add log entry
+  const addLog = (message, type = 'info') => {
+    const timestamp = new Date().toISOString().split('T')[1].split('.')[0]
+    const logEntry = `[${timestamp}] ${type.toUpperCase()}: ${message}`
+    console.log(logEntry)
+    
+    setDebugData(prev => ({
+      ...prev,
+      logs: [...prev.logs, { message, type, timestamp }]
+    }))
+  }
+
+  // Simulate the getAuxiliaryForTranslation function from ConjugationModal
+  const getAuxiliaryForTranslation = (translationId, translations) => {
+    if (!translationId) return 'avere'
+
+    const translation = translations.find(t => t.id === translationId)
+    const auxiliary = translation?.context_metadata?.auxiliary
+
+    addLog(`Auxiliary lookup - Translation: "${translation?.translation}", Result: ${auxiliary || 'avere'}`, 'info')
+
+    return auxiliary || 'avere'
+  }
+
+  // Simulate building block detection from ConjugationModal
+  const findBuildingBlocks = (storedForms) => {
+    addLog(`Searching for building blocks in ${storedForms.length} stored forms`, 'info')
+
+    const participle = storedForms.find(f =>
+      f.tags?.includes('participio-passato') &&
+      f.tags?.includes('simple') &&
+      !f.tags?.includes('io') &&
+      !f.tags?.includes('tu') &&
+      !f.tags?.includes('lui')
+    )
+
+    const gerund = storedForms.find(f =>
+      f.tags?.includes('gerundio-presente') &&
+      f.tags?.includes('simple') &&
+      !f.tags?.includes('io') &&
+      !f.tags?.includes('tu') &&
+      !f.tags?.includes('lui')
+    )
+
+    if (participle) {
+      addLog(`✅ Participle found: "${participle.form_text}" with tags: [${participle.tags?.join(', ')}]`, 'success')
+    } else {
+      addLog(`❌ No participle found. Need: participio-passato + simple tags, no person tags`, 'error')
+    }
+
+    if (gerund) {
+      addLog(`✅ Gerund found: "${gerund.form_text}" with tags: [${gerund.tags?.join(', ')}]`, 'success')
+    } else {
+      addLog(`⚠️ No gerund found. Need: gerundio-presente + simple tags, no person tags`, 'warning')
+    }
+
+    return { participle, gerund }
+  }
+
+  // Test auxiliary patterns table
+  const testAuxiliaryPatterns = async () => {
+    addLog('Testing auxiliary_patterns table...', 'info')
+    
+    try {
+      const { data: patterns, error } = await supabase
+        .from('auxiliary_patterns')
+        .select('*')
+        .limit(5)
+
+      if (error) {
+        addLog(`❌ Auxiliary patterns error: ${error.message}`, 'error')
+        return []
+      }
+
+      if (!patterns || patterns.length === 0) {
+        addLog('❌ No auxiliary patterns found in database', 'error')
+        return []
+      }
+
+      addLog(`✅ Found ${patterns.length} auxiliary patterns`, 'success')
+      return patterns
+    } catch (error) {
+      addLog(`❌ Auxiliary patterns exception: ${error.message}`, 'error')
+      return []
+    }
+  }
+
+  // Test compound generation
+  const testCompoundGeneration = async (participle, auxiliaryType) => {
+    if (!participle) {
+      addLog('❌ Cannot test compound generation - no participle', 'error')
+      return []
+    }
+
+    addLog(`Testing compound generation with auxiliary: ${auxiliaryType}`, 'info')
+
+    try {
+      const generated = await auxiliaryService.generateCompoundForm(
+        auxiliaryType,
+        'passato-prossimo',
+        'prima-persona',
+        'singolare',
+        participle.form_text,
+        'I finished'
+      )
+
+      if (generated) {
+        addLog(`✅ Generated compound: "${generated.form_text}"`, 'success')
+        return [generated]
+      } else {
+        addLog('❌ Compound generation returned null', 'error')
+        return []
+      }
+    } catch (error) {
+      addLog(`❌ Compound generation error: ${error.message}`, 'error')
+      return []
+    }
+  }
+
+  // Main debug function
+  const runDebugTest = async () => {
+    setIsLoading(true)
+    setDebugData(prev => ({ ...prev, logs: [], errors: [] }))
+    
+    addLog('🔄 Starting auxiliary system debug test for "finire"', 'info')
+
+    try {
+      // Step 1: Load word
+      addLog('Step 1: Loading word "finire" from dictionary', 'info')
+      const { data: words, error: wordError } = await supabase
+        .from('dictionary')
+        .select('*')
+        .eq('italian', 'finire')
+        .single()
+
+      if (wordError || !words) {
+        addLog(`❌ Failed to load word: ${wordError?.message || 'Not found'}`, 'error')
+        return
+      }
+
+      addLog(`✅ Word loaded: ${words.italian} (${words.word_type})`, 'success')
+
+      // Step 2: Load translations
+      addLog('Step 2: Loading translations', 'info')
+      const { data: translations, error: translationError } = await supabase
+        .from('word_translations')
+        .select(`
+          id,
+          translation,
+          display_priority,
+          context_metadata,
+          usage_notes,
+          frequency_estimate
+        `)
+        .eq('word_id', words.id)
+        .order('display_priority')
+
+      if (translationError) {
+        addLog(`❌ Failed to load translations: ${translationError.message}`, 'error')
+        return
+      }
+
+      addLog(`✅ Loaded ${translations?.length || 0} translations`, 'success')
+      translations?.forEach((t, i) => {
+        addLog(`  ${i + 1}. "${t.translation}" (priority: ${t.display_priority}, auxiliary: ${t.context_metadata?.auxiliary || 'undefined'})`, 'info')
+      })
+
+      // Step 3: Set selected translation
+      const primaryTranslation = translations?.find(t => t.display_priority === 1) || translations?.[0]
+      const selectedTranslationId = primaryTranslation?.id
+
+      if (selectedTranslationId) {
+        addLog(`✅ Selected translation: "${primaryTranslation.translation}" (ID: ${selectedTranslationId})`, 'success')
+      } else {
+        addLog('❌ No translation selected', 'error')
+      }
+
+      // Step 4: Test auxiliary lookup
+      const auxiliaryLookup = selectedTranslationId 
+        ? getAuxiliaryForTranslation(selectedTranslationId, translations)
+        : null
+
+      // Step 5: Load word forms
+      addLog('Step 5: Loading word forms', 'info')
+      const { data: storedForms, error: formsError } = await supabase
+        .from('word_forms')
+        .select(`
+          *,
+          form_translations (
+            word_translation_id,
+            translation,
+            assignment_method
+          )
+        `)
+        .eq('word_id', words.id)
+        .eq('form_type', 'conjugation')
+
+      if (formsError) {
+        addLog(`❌ Failed to load forms: ${formsError.message}`, 'error')
+        return
+      }
+
+      addLog(`✅ Loaded ${storedForms?.length || 0} word forms`, 'success')
+
+      // Step 6: Find building blocks
+      const buildingBlocks = findBuildingBlocks(storedForms || [])
+
+      // Step 7: Test auxiliary patterns
+      const auxiliaryPatterns = await testAuxiliaryPatterns()
+
+      // Step 8: Test compound generation
+      let generatedCompounds = []
+      if (buildingBlocks.participle && auxiliaryLookup) {
+        generatedCompounds = await testCompoundGeneration(buildingBlocks.participle, auxiliaryLookup)
+      }
+
+      // Update state
+      setDebugData(prev => ({
+        ...prev,
+        word: words,
+        translations: translations || [],
+        selectedTranslationId,
+        auxiliaryLookup,
+        storedForms: storedForms || [],
+        buildingBlocks,
+        auxiliaryPatterns,
+        generatedCompounds
+      }))
+
+      addLog('🎯 Debug test completed', 'success')
+
+    } catch (error) {
+      addLog(`❌ Debug test failed: ${error.message}`, 'error')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  // Test all auxiliary lookups
+  const testAllAuxiliaryLookups = () => {
+    addLog('🧪 Testing auxiliary lookup for all translations:', 'info')
+    debugData.translations.forEach((translation, index) => {
+      const auxiliary = getAuxiliaryForTranslation(translation.id, debugData.translations)
+      addLog(`  ${index + 1}. "${translation.translation}" → ${auxiliary}`, 'info')
+    })
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto p-6 bg-gray-50 min-h-screen">
+      <div className="bg-white rounded-lg shadow-lg p-6">
+        
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-3xl font-bold text-gray-800">
+            🔧 Auxiliary System Debugger - REAL DATA
+          </h1>
+          <button
+            onClick={runDebugTest}
+            disabled={isLoading}
+            className={`px-6 py-3 rounded-lg font-semibold transition-all ${
+              isLoading 
+                ? 'bg-gray-400 text-gray-200 cursor-not-allowed' 
+                : 'bg-blue-600 text-white hover:bg-blue-700 hover:shadow-lg'
+            }`}
+          >
+            {isLoading ? '🔄 Testing...' : '🔍 Test "Finire" System'}
+          </button>
+        </div>
+
+        {/* Quick Summary */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+          <div className="bg-blue-50 p-4 rounded-lg text-center">
+            <div className="text-2xl font-bold text-blue-600">{debugData.translations.length}</div>
+            <div className="text-sm text-blue-800">Translations</div>
+          </div>
+          <div className="bg-green-50 p-4 rounded-lg text-center">
+            <div className="text-2xl font-bold text-green-600">{debugData.storedForms.length}</div>
+            <div className="text-sm text-green-800">Stored Forms</div>
+          </div>
+          <div className="bg-purple-50 p-4 rounded-lg text-center">
+            <div className="text-2xl font-bold text-purple-600">
+              {debugData.buildingBlocks.participle ? '✅' : '❌'}
+            </div>
+            <div className="text-sm text-purple-800">Participle Found</div>
+          </div>
+          <div className="bg-orange-50 p-4 rounded-lg text-center">
+            <div className="text-2xl font-bold text-orange-600">{debugData.generatedCompounds.length}</div>
+            <div className="text-sm text-orange-800">Generated Forms</div>
+          </div>
+        </div>
+
+        {/* Main Content Grid */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          
+          {/* Translations */}
+          <div className="bg-green-50 rounded-lg p-4">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-lg font-semibold text-green-800">🌍 Translations</h3>
+              {debugData.translations.length > 0 && (
+                <button
+                  onClick={testAllAuxiliaryLookups}
+                  className="text-sm bg-green-600 text-white px-3 py-1 rounded hover:bg-green-700"
+                >
+                  Test All
+                </button>
+              )}
+            </div>
+            <div className="space-y-2">
+              {debugData.translations.map((translation, index) => (
+                <div 
+                  key={translation.id} 
+                  className={`p-3 rounded border-2 ${
+                    translation.id === debugData.selectedTranslationId 
+                      ? 'border-green-500 bg-green-100' 
+                      : 'border-gray-200 bg-white'
+                  }`}
+                >
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="font-semibold">{index + 1}. {translation.translation}</span>
+                    {translation.id === debugData.selectedTranslationId && (
+                      <span className="text-green-600 text-sm font-bold">✓ SELECTED</span>
+                    )}
+                  </div>
+                  <div className="text-xs text-gray-600 grid grid-cols-2 gap-2">
+                    <div><strong>Priority:</strong> {translation.display_priority}</div>
+                    <div><strong>Auxiliary:</strong> 
+                      <span className={`ml-1 px-1 rounded ${
+                        translation.context_metadata?.auxiliary === 'avere' ? 'bg-blue-100 text-blue-800' :
+                        translation.context_metadata?.auxiliary === 'essere' ? 'bg-pink-100 text-pink-800' :
+                        'bg-gray-100 text-gray-600'
+                      }`}>
+                        {translation.context_metadata?.auxiliary || 'undefined'}
+                      </span>
+                    </div>
+                    <div><strong>Usage:</strong> {translation.context_metadata?.usage || 'undefined'}</div>
+                    <div><strong>Notes:</strong> {translation.usage_notes || 'None'}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Building Blocks */}
+          <div className="bg-orange-50 rounded-lg p-4">
+            <h3 className="text-lg font-semibold text-orange-800 mb-3">🧱 Building Blocks</h3>
+            <div className="space-y-3">
+              <div className="p-3 bg-white rounded border">
+                <div className="font-semibold text-sm mb-2">Participle (for compound tenses)</div>
+                {debugData.buildingBlocks.participle ? (
+                  <div className="text-sm space-y-1">
+                    <div><strong>Form:</strong> <code className="bg-gray-100 px-1 rounded">{debugData.buildingBlocks.participle.form_text}</code></div>
+                    <div><strong>Tags:</strong> <code className="bg-gray-100 px-1 rounded text-xs">{debugData.buildingBlocks.participle.tags?.join(', ')}</code></div>
+                    <div><strong>Form Translations:</strong> {debugData.buildingBlocks.participle.form_translations?.length || 0}</div>
+                  </div>
+                ) : (
+                  <span className="text-red-600 font-semibold">❌ Not found</span>
+                )}
+              </div>
+              
+              <div className="p-3 bg-white rounded border">
+                <div className="font-semibold text-sm mb-2">Gerund (for progressive tenses)</div>
+                {debugData.buildingBlocks.gerund ? (
+                  <div className="text-sm space-y-1">
+                    <div><strong>Form:</strong> <code className="bg-gray-100 px-1 rounded">{debugData.buildingBlocks.gerund.form_text}</code></div>
+                    <div><strong>Tags:</strong> <code className="bg-gray-100 px-1 rounded text-xs">{debugData.buildingBlocks.gerund.tags?.join(', ')}</code></div>
+                    <div><strong>Form Translations:</strong> {debugData.buildingBlocks.gerund.form_translations?.length || 0}</div>
+                  </div>
+                ) : (
+                  <span className="text-orange-600 font-semibold">⚠️ Not found</span>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Auxiliary Lookup Result */}
+          <div className="bg-purple-50 rounded-lg p-4">
+            <h3 className="text-lg font-semibold text-purple-800 mb-3">🔍 Auxiliary Lookup Result</h3>
+            <div className="space-y-2">
+              <div className="text-sm">
+                <strong>Selected Translation ID:</strong> 
+                <code className="ml-2 bg-gray-100 px-2 py-1 rounded">{debugData.selectedTranslationId || 'None'}</code>
+              </div>
+              <div className="text-sm">
+                <strong>Auxiliary Result:</strong>
+                <span className={`ml-2 px-3 py-1 rounded font-bold ${
+                  debugData.auxiliaryLookup === 'avere' ? 'bg-blue-100 text-blue-800' : 
+                  debugData.auxiliaryLookup === 'essere' ? 'bg-pink-100 text-pink-800' :
+                  'bg-gray-100 text-gray-800'
+                }`}>
+                  {debugData.auxiliaryLookup || 'undefined'}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Generated Compounds */}
+          <div className="bg-yellow-50 rounded-lg p-4">
+            <h3 className="text-lg font-semibold text-yellow-800 mb-3">⚡ Generated Compounds</h3>
+            {debugData.generatedCompounds.length > 0 ? (
+              <div className="space-y-2">
+                {debugData.generatedCompounds.map((compound, index) => (
+                  <div key={index} className="p-2 bg-white rounded border">
+                    <div className="font-semibold">{compound.form_text}</div>
+                    <div className="text-xs text-gray-600">
+                      <div>Translation: {compound.translation}</div>
+                      <div>Tags: {compound.tags?.join(', ')}</div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-yellow-700">No compounds generated yet</div>
+            )}
+          </div>
+        </div>
+
+        {/* Debug Logs */}
+        <div className="mt-6 bg-gray-50 rounded-lg p-4">
+          <h3 className="text-lg font-semibold text-gray-800 mb-3">📋 Debug Logs ({debugData.logs.length})</h3>
+          <div className="bg-black text-green-400 p-4 rounded font-mono text-sm max-h-96 overflow-y-auto">
+            {debugData.logs.length === 0 ? (
+              <div className="text-gray-500">No logs yet. Click "Test Finire System" to start.</div>
+            ) : (
+              debugData.logs.map((log, index) => (
+                <div key={index} className={`mb-1 ${
+                  log.type === 'error' ? 'text-red-400' :
+                  log.type === 'success' ? 'text-green-400' :
+                  log.type === 'warning' ? 'text-yellow-400' :
+                  'text-blue-400'
+                }`}>
+                  {log.message}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* Instructions */}
+        <div className="mt-6 bg-blue-50 border border-blue-200 rounded-lg p-4">
+          <h3 className="text-lg font-semibold text-blue-800 mb-2">📋 What This Will Show</h3>
+          <div className="text-sm text-blue-700 space-y-2">
+            <p><strong>Expected for "finire":</strong></p>
+            <ul className="list-disc list-inside space-y-1 ml-4">
+              <li>2 translations loaded (one with avere, one with essere)</li>
+              <li>Participle "finito" found with correct tags</li>
+              <li>Auxiliary lookup working for selected translation</li>
+              <li>Compound forms generated (like "ho finito")</li>
+            </ul>
+            <p className="mt-2"><strong>If something's wrong:</strong> The debug logs will show exactly where it breaks.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -980,8 +980,10 @@ const loadWordTranslations = async () => {
         const aux = getAux(baseForm)
         const allForms = conjugations[selectedMood]?.[selectedTense] || []
         const thirdPersonSingularForm = allForms.find((form) => {
-          if (form.tags?.includes('calculated-variant')) return false
+          // ①  same gender variant (null, fem‑sing, fem‑plur, …)
+          if (form.variant_type !== baseForm.variant_type) return false
 
+          // ②  accept any spelling of the 3ᵗᵉˢ pronoun
           const pron = extractTagValue(form.tags, 'pronoun')
           const byPronoun = pron && /^(lui\/?lei?|lei|lui)$/i.test(pron)
           const byPerson =
@@ -989,9 +991,10 @@ const loadWordTranslations = async () => {
             extractTagValue(form.tags, 'person') === 'terza-persona' &&
             form.tags?.includes('singolare')
 
-          const auxMatch = getAux(form) === aux
+          if (!(byPronoun || byPerson)) return false
 
-          return (byPronoun || byPerson) && auxMatch
+          // ③  stay on the same auxiliary track
+          return getAux(form) === getAux(baseForm)
         })
 
         if (thirdPersonSingularForm) {
@@ -1012,18 +1015,18 @@ const loadWordTranslations = async () => {
         const aux = getAux(baseForm)
         const allForms = conjugations[selectedMood]?.[selectedTense] || []
         const thirdPersonPluralForm = allForms.find((form) => {
-          if (form.tags?.includes('calculated-variant')) return false
+          if (form.variant_type !== baseForm.variant_type) return false
 
           const pron = extractTagValue(form.tags, 'pronoun')
-          const byPronoun = pron === 'loro'
+          const byPronoun = pron && /^loro$/i.test(pron)
           const byPerson =
             !pron &&
             extractTagValue(form.tags, 'person') === 'terza-persona' &&
             form.tags?.includes('plurale')
 
-          const auxMatch = getAux(form) === aux
+          if (!(byPronoun || byPerson)) return false
 
-          return (byPronoun || byPerson) && auxMatch
+          return getAux(form) === getAux(baseForm)
         })
 
         if (thirdPersonPluralForm) {

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -200,6 +200,8 @@ const loadConjugations = async () => {
   setIsLoading(true)
   try {
     console.log('🔄 Loading conjugations for:', word.italian)
+    console.log('🔍 DIAGNOSTIC: selectedTranslationId:', selectedTranslationId)
+    console.log('🔍 DIAGNOSTIC: wordTranslations length:', wordTranslations.length)
 
     const { data, error } = await supabase
   .from('word_forms')
@@ -261,14 +263,20 @@ const loadConjugations = async () => {
     const auxiliaryType = getAuxiliaryForTranslation(selectedTranslationId)
     console.log('🔧 Generating compounds with auxiliary:', auxiliaryType)
 
-    // Find building blocks (participles and gerunds)
+    // Find clean building blocks (not person-specific compound forms)
     const participle = storedForms.find(f =>
-      f.tags?.includes('participio-passato') ||
-      (f.tags?.includes('participio') && !f.tags?.includes('presente'))
+      f.tags?.includes('participio-passato') &&
+      f.tags?.includes('simple') &&
+      !f.tags?.includes('io') &&
+      !f.tags?.includes('tu') &&
+      !f.tags?.includes('lui')
     )
     const gerund = storedForms.find(f =>
-      f.tags?.includes('gerundio-presente') ||
-      (f.tags?.includes('gerundio') && !f.tags?.includes('passato'))
+      f.tags?.includes('gerundio-presente') &&
+      f.tags?.includes('simple') &&
+      !f.tags?.includes('io') &&
+      !f.tags?.includes('tu') &&
+      !f.tags?.includes('lui')
     )
 
     if (!participle && !gerund) {

--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -202,28 +202,19 @@ const loadConjugations = async () => {
     console.log('🔄 Loading conjugations for:', word.italian)
 
     const { data, error } = await supabase
-      .from('word_forms')
-      .select(`
-        *,
-        word_audio_metadata!audio_metadata_id(
-          audio_filename,
-          azure_voice_name,
-          duration_seconds
-        ),
-        form_translations (
-          word_translation_id,
-          translation,
-          assignment_method,
-          word_translations (
-            id,
-            translation
-          )
-        )
-      `)
-      .eq('word_id', word.id)
-      .eq('form_type', 'conjugation')
-      .order('tags')
-
+  .from('word_forms')
+  .select(`
+    *,
+    form_translations (
+      word_translation_id,
+      translation,
+      assignment_method
+    )
+  `)
+  .eq('word_id', word.id)
+  .eq('form_type', 'conjugation')
+  .order('tags')
+    
     if (error) throw error
 
     console.log('📊 Raw forms loaded:', data?.length || 0)

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -283,6 +283,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
   // Show first 2 translations, rest are "additional"
   const visibleTranslations = translations.slice(0, 2)
   const additionalTranslations = translations.slice(2)
+  const fallbackTranslation = translations[0]?.translation || ''
 
   // Format context hint for display
   const formatContextHint = (contextInfo, usageNotes) => {
@@ -456,7 +457,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
               </div>
               <div className="flex items-center mr-2">
                 <span className="text-base text-gray-900 font-medium">
-                  {word.english}
+                  {fallbackTranslation}
                 </span>
               </div>
               <div className="flex-1"></div>

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -278,7 +278,15 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
   ]
 
   // Get translations - use processedTranslations from EnhancedDictionarySystem
-  const translations = word.processedTranslations || []
+  const translations =
+    word.processedTranslations ||
+    (word.word_translations || []).map(t => ({
+      id: t.id,
+      translation: t.translation,
+      isPrimary: t.display_priority === 1,
+      contextInfo: null,
+      usageNotes: t.usage_notes
+    })) || []
 
   // Show first 2 translations, rest are "additional"
   const visibleTranslations = translations.slice(0, 2)

--- a/lib/auxiliary-pattern-service.js
+++ b/lib/auxiliary-pattern-service.js
@@ -56,6 +56,7 @@ export class AuxiliaryPatternService {
       form_type: 'conjugation',
       tags: [tenseTag, person, plurality, 'compound', 'generated'],
       auxiliary_used: pattern[auxiliaryColumn],
+      auxiliary_type: auxiliaryType,
       building_block: buildingBlock,
       is_generated: true
     };

--- a/lib/enhanced-dictionary-system.js
+++ b/lib/enhanced-dictionary-system.js
@@ -15,41 +15,29 @@ export class EnhancedDictionarySystem {
    */
   async loadWordsWithTranslations(searchTerm = '', filters = {}) {
     try {
-      console.log('🔍 Loading words with translations:', { searchTerm, filters });
+            // Test basic relationship query
+            const { data: testData, error: testError } = await this.supabase
+            .from('dictionary') 
+            .select('italian, word_translations(*)')
+            .limit(1);
+
+            console.log('🔍 Relationship test:', { testData, testError });
+          
+
 
       // Build the comprehensive query that loads everything we need
       let query = this.supabase
         .from('dictionary')
         .select(`
-          id,
-          italian,
-          word_type,
-          tags,
-          phonetic_pronunciation,
-          created_at,
-          word_translations(
-            id,
-            translation,
-            display_priority,
-            context_metadata,
-            usage_notes,
-            frequency_estimate
-          ),
-          word_audio_metadata(
-            id,
-            audio_filename,
-            azure_voice_name,
-            duration_seconds
-          )
+          *,
+          word_translations(*)
         `)
         .order('italian', { ascending: true });
 
-      // Apply search filter across both Italian and all translations
+      // FIXED - proper relationship search
       if (searchTerm) {
-        // Search both dictionary and translations
-        query = query.or(
-          `italian.ilike.%${searchTerm}%,word_translations.translation.ilike.%${searchTerm}%`
-        );
+        query = query.or(`italian.ilike.%${searchTerm}%`);
+        // Note: Translation search needs separate query due to Supabase limitations
       }
 
       // Apply word type filter
@@ -111,6 +99,7 @@ export class EnhancedDictionarySystem {
   /**
    * Process translations for display with proper prioritization and context info
    */
+  // Sort translations by priority and enrich them for display
   processTranslationsForDisplay(translations) {
     if (!translations || translations.length === 0) return [];
 

--- a/lib/enhanced-dictionary-system.js
+++ b/lib/enhanced-dictionary-system.js
@@ -23,7 +23,6 @@ export class EnhancedDictionarySystem {
         .select(`
           id,
           italian,
-          english,
           word_type,
           tags,
           phonetic_pronunciation,
@@ -48,7 +47,9 @@ export class EnhancedDictionarySystem {
       // Apply search filter across both Italian and all translations
       if (searchTerm) {
         // Search both dictionary and translations
-        query = query.or(`italian.ilike.%${searchTerm}%,english.ilike.%${searchTerm}%`);
+        query = query.or(
+          `italian.ilike.%${searchTerm}%,word_translations.translation.ilike.%${searchTerm}%`
+        );
       }
 
       // Apply word type filter

--- a/lib/variant-calculator.js
+++ b/lib/variant-calculator.js
@@ -317,7 +317,9 @@ export class VariantCalculator {
         ipa: femPlurIPA,
         translation: storedForm.translation,
         form_translations: storedForm.form_translations
-          ? storedForm.form_translations.map(ft => ({ ...ft }))
+          ? storedForm.form_translations
+              .map(ft => ({ ...ft }))
+              .sort((a, b) => (a.english.startsWith('you ') ? -1 : 1))
           : [],
         tags: [...(storedForm.tags || []), 'feminine', 'calculated-variant'],
         base_form_id: storedForm.id,
@@ -336,7 +338,9 @@ export class VariantCalculator {
         ipa: femSingIPA,
         translation: storedForm.translation,
         form_translations: storedForm.form_translations
-          ? storedForm.form_translations.map(ft => ({ ...ft }))
+          ? storedForm.form_translations
+              .map(ft => ({ ...ft }))
+              .sort((a, b) => (a.english.startsWith('you ') ? -1 : 1))
           : [],
         tags: [...(storedForm.tags || []), 'feminine', 'calculated-variant'],
         base_form_id: storedForm.id,
@@ -354,7 +358,9 @@ export class VariantCalculator {
         ipa: masPlurIPA,
         translation: storedForm.translation,
         form_translations: storedForm.form_translations
-          ? storedForm.form_translations.map(ft => ({ ...ft }))
+          ? storedForm.form_translations
+              .map(ft => ({ ...ft }))
+              .sort((a, b) => (a.english.startsWith('you ') ? -1 : 1))
           : [],
         tags: [...(storedForm.tags || []), 'masculine', 'calculated-variant'],
         base_form_id: storedForm.id,
@@ -372,7 +378,9 @@ export class VariantCalculator {
         ipa: femPlurIPA2,
         translation: storedForm.translation,
         form_translations: storedForm.form_translations
-          ? storedForm.form_translations.map(ft => ({ ...ft }))
+          ? storedForm.form_translations
+              .map(ft => ({ ...ft }))
+              .sort((a, b) => (a.english.startsWith('you ') ? -1 : 1))
           : [],
         tags: [...(storedForm.tags || []), 'feminine', 'calculated-variant'],
         base_form_id: storedForm.id,

--- a/lib/variant-calculator.js
+++ b/lib/variant-calculator.js
@@ -96,6 +96,78 @@ export class VariantCalculator {
       console.log('✅ -ati unchanged:', participle);
       return participle; // masculine plural (original)
     }
+
+    // REGULAR -ITI PATTERN (plural base)
+    if (participle.endsWith('iti')) {
+      const stem = participle.slice(0, -3); // Remove 'iti'
+      if (targetGender === 'feminine' && targetNumber === 'plural') {
+        const result = stem + 'ite';
+        console.log('✅ -iti fem-plur:', participle, '→', result);
+        return result;
+      }
+      console.log('✅ -iti unchanged:', participle);
+      return participle; // masculine plural (original)
+    }
+
+    // REGULAR -UTI PATTERN (plural base)
+    if (participle.endsWith('uti')) {
+      const stem = participle.slice(0, -3); // Remove 'uti'
+      if (targetGender === 'feminine' && targetNumber === 'plural') {
+        const result = stem + 'ute';
+        console.log('✅ -uti fem-plur:', participle, '→', result);
+        return result;
+      }
+      console.log('✅ -uti unchanged:', participle);
+      return participle; // masculine plural (original)
+    }
+
+    // IRREGULAR -TTI PATTERN (plural base)
+    if (participle.endsWith('tti')) {
+      const stem = participle.slice(0, -3); // Remove 'tti'
+      if (targetGender === 'feminine' && targetNumber === 'plural') {
+        const result = stem + 'tte';
+        console.log('✅ -tti fem-plur:', participle, '→', result);
+        return result;
+      }
+      console.log('✅ -tti unchanged:', participle);
+      return participle; // masculine plural (original)
+    }
+
+    // IRREGULAR -SI PATTERN (plural base)
+    if (participle.endsWith('si')) {
+      const stem = participle.slice(0, -2); // Remove 'si'
+      if (targetGender === 'feminine' && targetNumber === 'plural') {
+        const result = stem + 'se';
+        console.log('✅ -si fem-plur:', participle, '→', result);
+        return result;
+      }
+      console.log('✅ -si unchanged:', participle);
+      return participle; // masculine plural (original)
+    }
+
+    // IRREGULAR -STI PATTERN (plural base)
+    if (participle.endsWith('sti')) {
+      const stem = participle.slice(0, -3); // Remove 'sti'
+      if (targetGender === 'feminine' && targetNumber === 'plural') {
+        const result = stem + 'ste';
+        console.log('✅ -sti fem-plur:', participle, '→', result);
+        return result;
+      }
+      console.log('✅ -sti unchanged:', participle);
+      return participle; // masculine plural (original)
+    }
+
+    // GENERIC -TI PATTERN (plural base)
+    if (participle.endsWith('ti')) {
+      const stem = participle.slice(0, -2); // Remove 'ti'
+      if (targetGender === 'feminine' && targetNumber === 'plural') {
+        const result = stem + 'te';
+        console.log('✅ -ti fem-plur:', participle, '→', result);
+        return result;
+      }
+      console.log('✅ -ti unchanged:', participle);
+      return participle; // masculine plural (original)
+    }
     
     // REGULAR -ITO PATTERN (finito, partito, servito)
     if (participle.endsWith('ito')) {
@@ -252,7 +324,7 @@ export class VariantCalculator {
         pattern_type: variantPattern.type
       });
     } else {
-      // For singular stored forms, only calculate feminine singular
+      // For singular stored forms, calculate all three variants
       const femSingForm = this.transformParticiple(storedForm.form_text, 'feminine', 'singular');
       const femSingPhonetic = this.transformPhonetic(storedForm.phonetic_form, storedForm.form_text, femSingForm);
       const femSingIPA = this.transformIPA(storedForm.ipa, storedForm.form_text, femSingForm);
@@ -262,6 +334,42 @@ export class VariantCalculator {
         form_text: femSingForm,
         phonetic_form: femSingPhonetic,
         ipa: femSingIPA,
+        translation: storedForm.translation,
+        form_translations: storedForm.form_translations
+          ? storedForm.form_translations.map(ft => ({ ...ft }))
+          : [],
+        tags: [...(storedForm.tags || []), 'feminine', 'calculated-variant'],
+        base_form_id: storedForm.id,
+        pattern_type: variantPattern.type
+      });
+
+      const masPlurForm = this.transformParticiple(storedForm.form_text, 'masculine', 'plural');
+      const masPlurPhonetic = this.transformPhonetic(storedForm.phonetic_form, storedForm.form_text, masPlurForm);
+      const masPlurIPA = this.transformIPA(storedForm.ipa, storedForm.form_text, masPlurForm);
+
+      variants.push({
+        variant_type: 'mas-plur',
+        form_text: masPlurForm,
+        phonetic_form: masPlurPhonetic,
+        ipa: masPlurIPA,
+        translation: storedForm.translation,
+        form_translations: storedForm.form_translations
+          ? storedForm.form_translations.map(ft => ({ ...ft }))
+          : [],
+        tags: [...(storedForm.tags || []), 'masculine', 'calculated-variant'],
+        base_form_id: storedForm.id,
+        pattern_type: variantPattern.type
+      });
+
+      const femPlurForm2 = this.transformParticiple(storedForm.form_text, 'feminine', 'plural');
+      const femPlurPhonetic2 = this.transformPhonetic(storedForm.phonetic_form, storedForm.form_text, femPlurForm2);
+      const femPlurIPA2 = this.transformIPA(storedForm.ipa, storedForm.form_text, femPlurForm2);
+
+      variants.push({
+        variant_type: 'fem-plur',
+        form_text: femPlurForm2,
+        phonetic_form: femPlurPhonetic2,
+        ipa: femPlurIPA2,
         translation: storedForm.translation,
         form_translations: storedForm.form_translations
           ? storedForm.form_translations.map(ft => ({ ...ft }))
@@ -284,16 +392,28 @@ export class VariantCalculator {
   // UTILITY FUNCTION - Get all forms (stored + calculated)
   static getAllForms(storedForms, wordTags) {
     const allForms = [...storedForms]; // Start with stored forms
-    
+
     storedForms.forEach(storedForm => {
       const variants = this.calculateGenderVariants(storedForm, wordTags);
       if (variants) {
         allForms.push(...variants);
       }
     });
-    
+
     return allForms;
   }
+}
+
+// Simple helper to expose variant calculation for a single form
+export function calculateVariants(baseForm) {
+  const aux = baseForm.auxiliary_type ||
+    ((baseForm.word_tags || []).includes('essere-auxiliary') ? 'essere' : 'avere')
+
+  if (aux !== 'essere') return []
+
+  const wordTags = baseForm.word_tags || []
+  const variants = VariantCalculator.calculateGenderVariants(baseForm, wordTags)
+  return variants || []
 }
 
 // TESTING UTILITIES (Remove in production)


### PR DESCRIPTION
## Summary
- extend `ConjugationModal` with AuxiliaryPatternService
- add helpers for dynamic auxiliary detection and compound form generation
- reload conjugations when translation changes

## Testing
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_688766aacbb483298c2f800e52404a83