### PR TITLE
Fix WordCard fallback translation

### DIFF
--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -283,6 +283,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
   // Show first 2 translations, rest are "additional"
   const visibleTranslations = translations.slice(0, 2)
   const additionalTranslations = translations.slice(2)
+  const fallbackTranslation = translations[0]?.translation || ''
 
   // Format context hint for display
   const formatContextHint = (contextInfo, usageNotes) => {
@@ -456,7 +457,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
               </div>
               <div className="flex items-center mr-2">
                 <span className="text-base text-gray-900 font-medium">
-                  {word.english}
+                  {fallbackTranslation}
                 </span>
               </div>
               <div className="flex-1"></div>


### PR DESCRIPTION
## Summary
- use translation data for fallback rendering in `WordCard`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68879b272b2483299f972e9c8f80f6b4