### PR TITLE
Fix missing translations

### DIFF
--- a/lib/enhanced-dictionary-system.js
+++ b/lib/enhanced-dictionary-system.js
@@ -86,13 +86,40 @@ export class EnhancedDictionarySystem {
   async enhanceWordWithTranslations(word) {
     const enhanced = { ...word };
 
+    // Ensure translations are loaded directly from word_translations table if missing
+    let translations = word.word_translations;
+    if (!translations || translations.length === 0) {
+      try {
+        const { data, error } = await this.supabase
+          .from('word_translations')
+          .select(`
+            id,
+            translation,
+            display_priority,
+            context_metadata,
+            usage_notes,
+            frequency_estimate
+          `)
+          .eq('word_id', word.id)
+          .order('display_priority');
+
+        if (error) throw error;
+        translations = data || [];
+      } catch (err) {
+        console.error('Error fetching translations for word', word.id, err);
+        translations = [];
+      }
+    }
+
+    enhanced.word_translations = translations;
+
     // Generate articles for nouns (existing logic)
     if (word.word_type === 'NOUN') {
       enhanced.articles = this.generateArticles(word);
     }
 
     // Process translations for display with priority ordering
-    enhanced.processedTranslations = this.processTranslationsForDisplay(word.word_translations || []);
+    enhanced.processedTranslations = this.processTranslationsForDisplay(translations);
 
     // Process tags for visual display
     enhanced.processedTags = this.processTagsForDisplay(word.tags, word.word_type);


### PR DESCRIPTION
## Summary
- ensure word translations are fetched directly from `word_translations`

## Testing
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6887a3696d108329a278ca070fb55717