### PR TITLE
Fix conjugation modal auxiliary load order

### DIFF
--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -854,8 +854,6 @@ const loadWordTranslations = async () => {
     setIsContentChanging(true)
     setTimeout(() => {
       setSelectedTranslationId(newTranslationId)
-      // 🚀 NEW: Reload conjugations with new auxiliary
-      loadConjugations()
       setIsContentChanging(false)
     }, 150)
   }
@@ -1039,10 +1037,15 @@ const loadWordTranslations = async () => {
 
   useEffect(() => {
     if (isOpen && word) {
-      loadConjugations()
       loadWordTranslations()
     }
   }, [isOpen, word])
+
+  useEffect(() => {
+    if (isOpen && word && selectedTranslationId) {
+      loadConjugations()
+    }
+  }, [isOpen, word, selectedTranslationId])
 
   useEffect(() => {
     // Set default tense when mood changes


### PR DESCRIPTION
## Summary
- fix initial auxiliary generation by loading translations first
- trigger conjugation load when translation is available
- adjust translation change handler

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6887f03b17808329bfc529e90fad4c96