### PR TITLE
Fix conjugation load order

### DIFF
--- a/components/ConjugationModal.js
+++ b/components/ConjugationModal.js
@@ -854,8 +854,6 @@ const loadWordTranslations = async () => {
     setIsContentChanging(true)
     setTimeout(() => {
       setSelectedTranslationId(newTranslationId)
-      // 🚀 NEW: Reload conjugations with new auxiliary
-      loadConjugations()
       setIsContentChanging(false)
     }, 150)
   }
@@ -1039,10 +1037,17 @@ const loadWordTranslations = async () => {
 
   useEffect(() => {
     if (isOpen && word) {
-      loadConjugations()
-      loadWordTranslations()
+      loadWordTranslations().then(() => {
+        loadConjugations()
+      })
     }
   }, [isOpen, word])
+
+  useEffect(() => {
+    if (selectedTranslationId && wordTranslations.length > 0) {
+      loadConjugations()
+    }
+  }, [selectedTranslationId])
 
   useEffect(() => {
     // Set default tense when mood changes


### PR DESCRIPTION
## Summary
- load word translations before conjugations in ConjugationModal
- stop calling `loadConjugations` in `handleTranslationChange`
- reload conjugations when translation changes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887f37807448329bcfa5779c39c0ada