### PR TITLE
fix: add deprecated tag rules and terminology converter

### DIFF
--- a/lib/universalTerminologyMappings.ts
+++ b/lib/universalTerminologyMappings.ts
@@ -567,9 +567,10 @@ export const ALL_TERMINOLOGY_MAPPINGS: TerminologyMapping[] = [
  * Create fast lookup maps for bidirectional conversion
  */
 export class TerminologyConverter {
-  private italianToUniversal = new Map<string, string>();
-  private universalToItalian = new Map<string, string>();
-  private legacyToUniversal = new Map<string, string>();
+  // Internal lookup tables for fast terminology conversion
+  private italianToUniversalMap = new Map<string, string>();
+  private universalToItalianMap = new Map<string, string>();
+  private legacyToUniversalMap = new Map<string, string>();
   private categoryMaps = new Map<string, Map<string, string>>();
 
   constructor() {
@@ -579,15 +580,15 @@ export class TerminologyConverter {
   private buildLookupMaps() {
     for (const mapping of ALL_TERMINOLOGY_MAPPINGS) {
       // Italian to Universal
-      this.italianToUniversal.set(mapping.italian.toLowerCase(), mapping.universal);
+      this.italianToUniversalMap.set(mapping.italian.toLowerCase(), mapping.universal);
       
       // Universal to Italian
-      this.universalToItalian.set(mapping.universal, mapping.italian);
+      this.universalToItalianMap.set(mapping.universal, mapping.italian);
       
       // Legacy to Universal (handle multiple legacy terms)
       if (mapping.legacy) {
         for (const legacyTerm of mapping.legacy) {
-          this.legacyToUniversal.set(legacyTerm.toLowerCase(), mapping.universal);
+          this.legacyToUniversalMap.set(legacyTerm.toLowerCase(), mapping.universal);
         }
       }
       
@@ -605,8 +606,8 @@ export class TerminologyConverter {
     }
     
     console.log('✅ Terminology converter initialized');
-    console.log(`📊 ${this.italianToUniversal.size} Italian → Universal mappings`);
-    console.log(`📊 ${this.legacyToUniversal.size} Legacy → Universal mappings`);
+    console.log(`📊 ${this.italianToUniversalMap.size} Italian → Universal mappings`);
+    console.log(`📊 ${this.legacyToUniversalMap.size} Legacy → Universal mappings`);
     console.log(`📊 ${this.categoryMaps.size} category-specific maps`);
   }
 
@@ -614,21 +615,21 @@ export class TerminologyConverter {
    * Convert Italian term to universal term
    */
   italianToUniversal(italianTerm: string): string | null {
-    return this.italianToUniversal.get(italianTerm.toLowerCase()) || null;
+    return this.italianToUniversalMap.get(italianTerm.toLowerCase()) || null;
   }
 
   /**
    * Convert universal term to Italian term
    */
   universalToItalian(universalTerm: string): string | null {
-    return this.universalToItalian.get(universalTerm) || null;
+    return this.universalToItalianMap.get(universalTerm) || null;
   }
 
   /**
    * Convert legacy term to universal term
    */
   legacyToUniversal(legacyTerm: string): string | null {
-    return this.legacyToUniversal.get(legacyTerm.toLowerCase()) || null;
+    return this.legacyToUniversalMap.get(legacyTerm.toLowerCase()) || null;
   }
 
   /**
@@ -644,7 +645,7 @@ export class TerminologyConverter {
     if (fromItalian) return fromItalian;
     
     // Check if it's already universal
-    if (this.universalToItalian.has(term)) return term;
+    if (this.universalToItalianMap.has(term)) return term;
     
     // Return as-is if no conversion found (with warning)
     console.warn(`⚠️ No universal mapping found for term: "${term}"`);
@@ -682,7 +683,7 @@ export class TerminologyConverter {
    * Validate that a term exists in the mapping system
    */
   isValidTerm(term: string): boolean {
-    return this.toUniversal(term) !== term || this.universalToItalian.has(term);
+    return this.toUniversal(term) !== term || this.universalToItalianMap.has(term);
   }
 
   /**

--- a/lib/verbComplianceRules.ts
+++ b/lib/verbComplianceRules.ts
@@ -530,9 +530,17 @@ export interface SystemComplianceReport {
  * Export all compliance rules for validation engine consumption
  */
 export const VERB_COMPLIANCE_RULES = {
-  wordLevel: WORD_LEVEL_REQUIRED_TAGS,
+  // Include both required and deprecated tag sets for word-level validation
+  wordLevel: {
+    ...WORD_LEVEL_REQUIRED_TAGS,
+    deprecatedTags: WORD_LEVEL_DEPRECATED_TAGS
+  },
   translationLevel: TRANSLATION_LEVEL_REQUIRED_METADATA,
-  formLevel: FORM_LEVEL_REQUIRED_TAGS,
+  // Form-level rules now expose deprecated tags as well
+  formLevel: {
+    ...FORM_LEVEL_REQUIRED_TAGS,
+    deprecatedTags: FORM_LEVEL_DEPRECATED_TAGS
+  },
   crossTable: CROSS_TABLE_VALIDATION_RULES,
   buildingBlocks: EPIC_BUILDING_BLOCK_REQUIREMENTS,
   scopeBoundaries: EPIC_SCOPE_BOUNDARY_RULES,

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- expose deprecated tag lists in VERB_COMPLIANCE_RULES for validators
- fix TerminologyConverter by separating internal maps from public methods
- add TypeScript config files

## Testing
- `NEXT_PUBLIC_SUPABASE_URL="http://localhost" NEXT_PUBLIC_SUPABASE_ANON_KEY="anon" npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fc1d1e9148329895f6d17fc24aa39