### PR TITLE
feat: connect validator to supabase

### DIFF
--- a/components/admin/AdminValidationInterface.tsx
+++ b/components/admin/AdminValidationInterface.tsx
@@ -399,75 +399,38 @@ const AdminValidationInterface = () => {
 
                 {/* Translation Level Issues */}
                 <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                  <h4 className="text-lg font-semibold text-gray-900 mb-4">Translation Level Analysis</h4>
+                  <h4 className="text-lg font-semibold text-gray-900 mb-4">Translation Analysis</h4>
                   <div className="space-y-4">
-                    {validationResult.translationLevelIssues.some(i => i.ruleId === 'no-translations') ? (
-                      <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
-                        <div className="text-red-800 font-medium">❌ No translations found</div>
-                        <div className="mt-2 text-sm text-red-700">
-                          <strong>Action:</strong> Create records in word_translations table with auxiliary and form_ids
+                    {validationResult.translationLevelIssues.length === 0 ? (
+                      <div className="p-4 bg-green-50 border border-green-200 rounded-lg">
+                        <div className="text-green-800 font-medium">✅ All translations properly configured</div>
+                        <div className="mt-2 text-sm text-green-700">
+                          All translations have required auxiliary and transitivity settings
                         </div>
                       </div>
                     ) : (
                       <div className="space-y-3">
-                        {/* Mock translation analysis - replace with real data */}
-                        <div className="border rounded-lg p-4">
-                          <div className="flex justify-between items-start mb-2">
-                            <h5 className="font-medium">Translation 1: "to speak"</h5>
-                            <span className="text-xs text-gray-500">Priority: 1</span>
-                          </div>
-                          <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
-                            <div>
-                              <span className="font-medium text-gray-700">Auxiliary:</span>
-                              <span className="ml-2 text-red-600">❌ Missing (need: avere/essere)</span>
+                        {validationResult.translationLevelIssues.map((issue, idx) => (
+                          <div key={idx} className="p-4 bg-red-50 border border-red-200 rounded-lg">
+                            <div className="text-red-800 font-medium text-sm">❌ {issue.message}</div>
+                            <div className="text-red-700 text-sm mt-1">
+                              <strong>Current:</strong> {JSON.stringify(issue.currentValue)}
                             </div>
-                            <div>
-                              <span className="font-medium text-gray-700">Transitivity:</span>
-                              <span className="ml-2 text-red-600">❌ Missing (need: transitive/intransitive)</span>
+                            <div className="text-red-700 text-sm">
+                              <strong>Expected:</strong> {issue.expectedValue}
                             </div>
-                            <div>
-                              <span className="font-medium text-gray-700">Form IDs:</span>
-                              <span className="ml-2 text-red-600">❌ Missing (need: array of form IDs)</span>
-                            </div>
+                            {issue.manualSteps && (
+                              <div className="mt-2 p-2 bg-red-100 rounded">
+                                <div className="text-red-800 font-medium text-xs">Actions:</div>
+                                <ul className="text-red-700 text-xs mt-1 list-decimal list-inside">
+                                  {issue.manualSteps.map((step, stepIdx) => (
+                                    <li key={stepIdx}>{step}</li>
+                                  ))}
+                                </ul>
+                              </div>
+                            )}
                           </div>
-                          <div className="mt-3 p-3 bg-yellow-50 border border-yellow-200 rounded text-sm">
-                            <strong>Required Actions:</strong>
-                            <ul className="mt-1 list-disc list-inside text-yellow-800">
-                              <li>Set context_metadata.auxiliary = "avere" (transitive verb)</li>
-                              <li>Set context_metadata.transitivity = "transitive"</li>
-                              <li>Add form_ids array with relevant form IDs</li>
-                            </ul>
-                          </div>
-                        </div>
-
-                        <div className="border rounded-lg p-4">
-                          <div className="flex justify-between items-start mb-2">
-                            <h5 className="font-medium">Translation 2: "to talk"</h5>
-                            <span className="text-xs text-gray-500">Priority: 2</span>
-                          </div>
-                          <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
-                            <div>
-                              <span className="font-medium text-gray-700">Auxiliary:</span>
-                              <span className="ml-2 text-red-600">❌ Missing (need: avere/essere)</span>
-                            </div>
-                            <div>
-                              <span className="font-medium text-gray-700">Transitivity:</span>
-                              <span className="ml-2 text-red-600">❌ Missing (need: transitive/intransitive)</span>
-                            </div>
-                            <div>
-                              <span className="font-medium text-gray-700">Form IDs:</span>
-                              <span className="ml-2 text-red-600">❌ Missing (need: array of form IDs)</span>
-                            </div>
-                          </div>
-                          <div className="mt-3 p-3 bg-yellow-50 border border-yellow-200 rounded text-sm">
-                            <strong>Required Actions:</strong>
-                            <ul className="mt-1 list-disc list-inside text-yellow-800">
-                              <li>Set context_metadata.auxiliary = "avere" (transitive verb)</li>
-                              <li>Set context_metadata.transitivity = "transitive"</li>
-                              <li>Add form_ids array with relevant form IDs</li>
-                            </ul>
-                          </div>
-                        </div>
+                        ))}
                       </div>
                     )}
                   </div>
@@ -674,22 +637,21 @@ const AdminValidationInterface = () => {
                         </div>
                       </div>
 
-                      <div className="p-3 bg-green-50 border border-green-200 rounded">
-                        <div className="text-green-800 font-medium text-sm">✅ English Translations Available</div>
-                        <div className="text-green-700 text-sm mt-1">
-                          134 form-translation assignments found in form_translations table
+                      {validationResult.crossTableIssues.length === 0 ? (
+                        <div className="p-3 bg-green-50 border border-green-200 rounded">
+                          <div className="text-green-800 font-medium text-sm">✅ All relationships working correctly</div>
+                          <div className="text-green-700 text-sm mt-1">
+                            Form-translation assignments are properly configured
+                          </div>
                         </div>
-                      </div>
-
-                      <div className="p-3 bg-blue-50 border border-blue-200 rounded">
-                        <div className="text-blue-800 font-medium text-sm">📊 Coverage Analysis</div>
-                        <div className="text-blue-700 text-sm mt-1 space-y-1">
-                          <div>• "to finish" (avere): 67/67 form_translations ✅</div>
-                          <div>• "to end" (essere): 67/67 form_translations ✅</div>
-                          <div>• All forms have English translations ✅</div>
-                          <div>• All translations cover forms ✅</div>
+                      ) : (
+                        <div className="p-3 bg-red-50 border border-red-200 rounded">
+                          <div className="text-red-800 font-medium text-sm">❌ Relationship Issues Found</div>
+                          <div className="text-red-700 text-sm mt-1">
+                            {validationResult.crossTableIssues.length} relationship problems detected
+                          </div>
                         </div>
-                      </div>
+                      )}
                     </div>
                   </div>
 


### PR DESCRIPTION
## Summary
- add in-page debug console to view validator output in real time
- route single-verb validation through `validateSpecificVerbWithDebug` for stepwise logging
- implement `validateSpecificVerbWithDebug` to fetch verb data from Supabase and run detailed checks with callback-based logging
- wire system-wide analysis to `validateConjugationSystemWithDebug` and enhance word, translation, and building-block checks for granular missing-item guidance
- drop non-existent `translation` field from word form loading and report missing building blocks as a detailed list in the admin UI
- expand single-verb debugging with exhaustive tag, translation, form, and building-block analysis and add detailed validation helpers
- add a comprehensive remediation section detailing word-level, translation-level, tense, and building-block fixes
- improve form analysis by grouping tenses by mood and augment orphaned-form detection with form-to-translation checks
- reorganize UI to present forms by mood groups with dedicated building-block and relationship diagnostics
- show missing progressive forms in Subjunctive and Conditional sections and adjust summary counts
- refactor validator to inspect form_translations assignments, drop deprecated form_ids arrays, and audit coverage for each translation
- refine form-translation relationship panel to highlight many-to-many architecture and actual coverage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=example-key npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689088fa1c408329a65599feffa25da4