### PR TITLE
feat: add detailed analysis to validator

### DIFF
--- a/lib/verbComplianceRules.ts
+++ b/lib/verbComplianceRules.ts
@@ -496,6 +496,43 @@ export interface VerbComplianceReport {
   migrationReadiness: boolean;
   priorityLevel: 'high' | 'medium' | 'low';
   estimatedFixTime: string;
+  detailedAnalysis?: {
+    auxiliaries: string[];
+    formCounts: {
+      byMood: { [mood: string]: { [tense: string]: number } };
+      byType: {
+        simple: number;
+        perfectCompound: number;
+        progressive: number;
+        total: number;
+      };
+      expectations: {
+        simple: number;
+        perfectCompound: number;
+        progressive: number;
+        total: number;
+      };
+    };
+    formTranslationCoverage: {
+      totalFormTranslations: number;
+      translationBreakdown: Array<{
+        translation: string;
+        auxiliary: string;
+        expected: number;
+        actual: number;
+        coverage: number;
+      }>;
+    };
+    orphanedRecords: {
+      formsWithoutTranslations: Array<{ id: number; text: string; tags: string[]; }>;
+      translationsWithoutForms: Array<{ id: string; translation: string; auxiliary: string; }>;
+      formsWithoutMoodTense: Array<{ id: number; text: string; tags: string[]; }>;
+      missingTags: {
+        buildingBlocks: Array<{ id: number; text: string; missingTag: string; }>;
+        auxiliaries: Array<{ id: number; text: string; expectedTag: string; }>;
+      };
+    };
+  };
 }
 
 export interface SystemComplianceReport {


### PR DESCRIPTION
## Summary
- extend `VerbComplianceReport` with optional `detailedAnalysis` field
- compute real auxiliary, form count, coverage and orphan record data in `validateSpecificVerbWithDebug`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894cd1e494c8329aeee241ebf26d7b5