### PR TITLE
feat: expose detailed validation analysis

### DIFF
--- a/lib/verbComplianceRules.ts
+++ b/lib/verbComplianceRules.ts
@@ -496,6 +496,43 @@ export interface VerbComplianceReport {
   migrationReadiness: boolean;
   priorityLevel: 'high' | 'medium' | 'low';
   estimatedFixTime: string;
+  detailedAnalysis?: {
+    auxiliaries: string[];
+    formCounts: {
+      byMood: { [mood: string]: { [tense: string]: number } };
+      byType: {
+        simple: number;
+        perfectCompound: number;
+        progressive: number;
+        total: number;
+      };
+      expectations: {
+        simple: number;
+        perfectCompound: number;
+        progressive: number;
+        total: number;
+      };
+    };
+    formTranslationCoverage: {
+      totalFormTranslations: number;
+      translationBreakdown: Array<{
+        translation: string;
+        auxiliary: string;
+        expected: number;
+        actual: number;
+        coverage: number;
+      }>;
+    };
+    orphanedRecords: {
+      formsWithoutTranslations: Array<{ id: number; text: string; tags: string[]; }>;
+      translationsWithoutForms: Array<{ id: string; translation: string; auxiliary: string; }>;
+      formsWithoutMoodTense: Array<{ id: number; text: string; tags: string[]; }>;
+      missingTags: {
+        buildingBlocks: Array<{ id: number; text: string; missingTag: string; }>;
+        auxiliaries: Array<{ id: number; text: string; expectedTag: string; }>;
+      };
+    };
+  };
 }
 
 export interface SystemComplianceReport {


### PR DESCRIPTION
## Summary
- add detailedAnalysis structure to verb compliance reports
- compute real form and translation metrics in validator
- display real validation data in admin interface
- group translation issues by translation in admin interface

## Testing
- `npm test` *(fails: Missing script: "test")*
- `NEXT_PUBLIC_SUPABASE_URL='http://example.com' NEXT_PUBLIC_SUPABASE_ANON_KEY='anon' npm run build` *(hangs during optimized build step)*

------
https://chatgpt.com/codex/tasks/task_e_689580add0608329be33c8cef7071ebf