### PR TITLE
feat: enhance validation summary and word analysis

### DIFF
--- a/lib/conjugationComplianceValidator.ts
+++ b/lib/conjugationComplianceValidator.ts
@@ -1102,7 +1102,7 @@ export class ConjugationComplianceValidator {
       const { data: word, error } = await this.supabase
         .from('dictionary')
         .select('*')
-        .eq('italian', verbItalian)
+        .ilike('italian', verbItalian)
         .eq('word_type', 'VERB')
         .single();
 
@@ -1661,7 +1661,7 @@ export class ConjugationComplianceValidator {
       const { data: word, error } = await this.supabase
         .from('dictionary')
         .select('*')
-        .eq('italian', verbItalian)
+        .ilike('italian', verbItalian)
         .eq('word_type', 'VERB')
         .single();
 


### PR DESCRIPTION
## Summary
- add real-data summary to validation results
- overhaul word-level analysis to show actual tag values and irregularity patterns
- enrich tense dropdowns with linked translations, duplicate detection, and auxiliary mismatch flags
- make verb lookup case-insensitive for validation queries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689700e61d7c8329b196560ee89f5baf