### PR TITLE
Improve conjugation validation with duplicate and auxiliary checks

### DIFF
--- a/lib/conjugationComplianceValidator.ts
+++ b/lib/conjugationComplianceValidator.ts
@@ -1102,7 +1102,7 @@ export class ConjugationComplianceValidator {
       const { data: word, error } = await this.supabase
         .from('dictionary')
         .select('*')
-        .eq('italian', verbItalian)
+        .ilike('italian', verbItalian)
         .eq('word_type', 'VERB')
         .single();
 


### PR DESCRIPTION
## Summary
- Search verbs case-insensitively in validator
- Detect duplicate verb forms and auxiliary mismatches in admin UI
- Warn about duplicate forms in expectations calculator and translation analysis

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6897181546f88329af48e28b40545541