### PR TITLE
feat: improve reciprocal translation handling

### DIFF
--- a/components/admin/AdminValidationInterface.tsx
+++ b/components/admin/AdminValidationInterface.tsx
@@ -994,12 +994,25 @@ const AdminValidationInterface = () => {
                                 {/* Translation Header */}
                                 <div className="flex justify-between items-start mb-3">
                                   <div>
-                                    <h6 className={`font-medium ${hasIssues ? 'text-red-900' : 'text-green-900'}`}>
+                                    <h6 className={`font-medium ${hasIssues ? 'text-red-900' : 'text-green-900'}`}> 
                                       Translation: "{translation.translation}"
+                                      {coverage?.isReciprocal && (
+                                        <span className="ml-2 px-2 py-1 text-xs bg-purple-100 text-purple-800 rounded font-medium">
+                                          🔄 RECIPROCAL
+                                        </span>
+                                      )}
+                                      {coverage?.isDirectReflexive && (
+                                        <span className="ml-2 px-2 py-1 text-xs bg-blue-100 text-blue-800 rounded font-medium">
+                                          🪞 REFLEXIVE
+                                        </span>
+                                      )}
                                     </h6>
                                     <div className="text-xs text-gray-600 mt-1 flex items-center gap-3">
                                       <span>Priority: {translation.display_priority}</span>
-                                      <span>Coverage: {coverage?.coverage || 0}% ({coverage?.actual || 0}/{130})</span>
+                                      <span>Coverage: {coverage?.coverage || 0}% ({coverage?.actual || 0}/{coverage?.expected || 130})</span>
+                                      {coverage?.isReciprocal && (
+                                        <span className="text-purple-600">Plural forms only</span>
+                                      )}
                                     </div>
                                   </div>
                                   <div className="flex items-center gap-2">
@@ -1377,14 +1390,8 @@ const AdminValidationInterface = () => {
                         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
                           <h4 className="text-lg font-semibold text-gray-900 mb-4">Form-Translation Analysis (REAL DATA)</h4>
 
-                          {/* Individual Translation Coverage with CORRECTED CALCULATIONS */}
                           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                             {analysis.formTranslationCoverage.translationBreakdown.map((translation, idx) => {
-                              // CORRECTED: Each translation expects 130 forms (51 simple + 49 compound + 30 progressive)
-                              // Not the total verb expectation of 179
-                              const expectedPerTranslation = 130; // Fixed per translation regardless of total auxiliaries
-                              const correctedCoverage = Math.round((translation.actual / expectedPerTranslation) * 100);
-                              
                               return (
                                 <div key={idx} className={`border rounded-lg p-4 ${
                                   idx === 0 ? 'border-purple-200 bg-purple-50' : 'border-indigo-200 bg-indigo-50'
@@ -1392,6 +1399,16 @@ const AdminValidationInterface = () => {
                                   <div className="flex justify-between items-start mb-2">
                                     <h6 className={`font-medium ${idx === 0 ? 'text-purple-900' : 'text-indigo-900'}`}>
                                       Translation: "{translation.translation}"
+                                      {translation.isReciprocal && (
+                                        <span className="ml-2 px-2 py-1 text-xs bg-purple-100 text-purple-800 rounded font-medium">
+                                          🔄 RECIPROCAL
+                                        </span>
+                                      )}
+                                      {translation.isDirectReflexive && (
+                                        <span className="ml-2 px-2 py-1 text-xs bg-blue-100 text-blue-800 rounded font-medium">
+                                          🪞 REFLEXIVE
+                                        </span>
+                                      )}
                                     </h6>
                                     <span className={`text-xs px-2 py-1 rounded ${
                                       idx === 0 ? 'bg-purple-200 text-purple-800' : 'bg-indigo-200 text-indigo-800'
@@ -1402,9 +1419,7 @@ const AdminValidationInterface = () => {
                                   <div className="space-y-2 text-sm">
                                     <div className="flex justify-between">
                                       <span className={idx === 0 ? 'text-purple-700' : 'text-indigo-700'}>Expected form_translations:</span>
-                                      <span className={`font-medium ${idx === 0 ? 'text-purple-800' : 'text-indigo-800'}`}>
-                                        {expectedPerTranslation}
-                                      </span>
+                                      <span className={`font-medium ${idx === 0 ? 'text-purple-800' : 'text-indigo-800'}`}>{translation.expected}</span>
                                     </div>
                                     <div className="flex justify-between">
                                       <span className={idx === 0 ? 'text-purple-700' : 'text-indigo-700'}>Actual form_translations:</span>
@@ -1412,14 +1427,14 @@ const AdminValidationInterface = () => {
                                     </div>
                                     <div className="flex justify-between">
                                       <span className={idx === 0 ? 'text-purple-700' : 'text-indigo-700'}>Coverage:</span>
-                                      <span className={`font-medium ${correctedCoverage === 100 ? 'text-green-600' : 'text-orange-600'}`}>
-                                        {correctedCoverage}% ({translation.actual}/{expectedPerTranslation})
+                                      <span className={`font-medium ${translation.coverage === 100 ? 'text-green-600' : 'text-orange-600'}`}>
+                                        {translation.coverage}% ({translation.actual}/{translation.expected})
                                       </span>
                                     </div>
-                                    {correctedCoverage < 100 && (
+                                    {translation.coverage < 100 && (
                                       <div className={`text-xs mt-2 ${idx === 0 ? 'text-purple-600' : 'text-indigo-600'}`}>
-                                        Missing: {expectedPerTranslation - translation.actual} form_translations 
-                                        ({Math.round((expectedPerTranslation - translation.actual)/6)} tense sets)
+                                        Missing: {translation.expected - translation.actual} form_translations
+                                        ({Math.round((translation.expected - translation.actual)/6)} tense sets)
                                       </div>
                                     )}
                                   </div>

--- a/lib/conjugationComplianceValidator.ts
+++ b/lib/conjugationComplianceValidator.ts
@@ -1083,11 +1083,69 @@ export class ConjugationComplianceValidator {
   }
 
   private calculateLinguisticAccuracy(reports: VerbComplianceReport[]): number {
-    const accurateVerbs = reports.filter(r => 
-      r.missingBuildingBlocks.length === 0 && 
+    const accurateVerbs = reports.filter(r =>
+      r.missingBuildingBlocks.length === 0 &&
       r.deprecatedContent.length === 0
     ).length;
     return Math.round((accurateVerbs / reports.length) * 100) || 0;
+  }
+
+  private calculateReciprocalExpectedForms(auxiliaryCount: number): number {
+    const finiteSimpleTenses = {
+      'presente': 3,
+      'imperfetto': 3,
+      'futuro-semplice': 3,
+      'passato-remoto': 3,
+      'congiuntivo-presente': 3,
+      'congiuntivo-imperfetto': 3,
+      'condizionale-presente': 3,
+      'imperativo-presente': 3
+    };
+
+    const compoundTenses = {
+      'passato-prossimo': 3,
+      'trapassato-prossimo': 3,
+      'futuro-anteriore': 3,
+      'trapassato-remoto': 3,
+      'congiuntivo-passato': 3,
+      'congiuntivo-trapassato': 3,
+      'condizionale-passato': 3,
+      'imperativo-passato': 3
+    };
+
+    const progressiveTenses = {
+      'presente-progressivo': 3,
+      'passato-progressivo': 3,
+      'futuro-progressivo': 3,
+      'congiuntivo-presente-progressivo': 3,
+      'condizionale-presente-progressivo': 3
+    };
+
+    const nonFiniteForms = {
+      'infinito-presente': 1,
+      'infinito-passato': auxiliaryCount,
+      'participio-presente': 1,
+      'participio-passato': 1,
+      'gerundio-presente': 1,
+      'gerundio-passato': auxiliaryCount
+    };
+
+    const simpleForms = Object.values(finiteSimpleTenses).reduce((sum, c) => sum + c, 0);
+    const compoundForms = Object.values(compoundTenses).reduce((sum, c) => sum + c, 0) * auxiliaryCount;
+    const progressiveForms = Object.values(progressiveTenses).reduce((sum, c) => sum + c, 0);
+    const nonFinite = Object.values(nonFiniteForms).reduce((sum, c) => sum + c, 0);
+
+    return simpleForms + compoundForms + progressiveForms + nonFinite;
+  }
+
+  private isReciprocalTranslation(translation: any): boolean {
+    const metadata = translation.context_metadata || {};
+    return metadata.usage === 'reciprocal' && metadata.plurality === 'plural-only';
+  }
+
+  private isDirectReflexiveTranslation(translation: any): boolean {
+    const metadata = translation.context_metadata || {};
+    return metadata.usage === 'direct-reflexive' && metadata.plurality === 'any';
   }
 
   /**
@@ -1393,14 +1451,20 @@ export class ConjugationComplianceValidator {
           ft => ft.word_translation_id === translation.id
         );
 
+        const expectedForThisTranslation = this.isReciprocalTranslation(translation)
+          ? this.calculateReciprocalExpectedForms(auxiliaryCount)
+          : 51 + 49 * 1 + 30;
+
         return {
           translation: translation.translation,
           auxiliary: translation.context_metadata?.auxiliary || 'unknown',
-          expected: expectations.total,
+          expected: expectedForThisTranslation,
           actual: translationFormTranslations.length,
           coverage: Math.round(
-            (translationFormTranslations.length / expectations.total) * 100
-          )
+            (translationFormTranslations.length / expectedForThisTranslation) * 100
+          ),
+          isReciprocal: this.isReciprocalTranslation(translation),
+          isDirectReflexive: this.isDirectReflexiveTranslation(translation)
         };
       });
 
@@ -1514,6 +1578,38 @@ export class ConjugationComplianceValidator {
       report.translationLevelIssues = this.validateTranslationLevelDetailed(translations || []);
       report.formLevelIssues = this.validateFormLevelDetailed(forms || [], true);
       report.missingBuildingBlocks = this.validateBuildingBlocksDetailed(forms || []);
+
+      (translations || []).forEach(translation => {
+        if (this.isReciprocalTranslation(translation)) {
+          const reciprocalFormIds = (formTranslations || [])
+            .filter(ft => ft.word_translation_id === translation.id)
+            .map(ft => ft.form_id);
+
+          const reciprocalForms = (forms || []).filter(f => reciprocalFormIds.includes(f.id));
+
+          const invalidSingularForms = reciprocalForms.filter(f =>
+            f.tags?.includes('singolare') &&
+            f.tags?.some(tag =>
+              ['prima-persona', 'seconda-persona', 'terza-persona'].includes(tag)
+            )
+          );
+
+          if (invalidSingularForms.length > 0) {
+            report.translationLevelIssues.push({
+              ruleId: 'reciprocal-singular-forms',
+              severity: 'high',
+              message: `Reciprocal translation "${translation.translation}" has invalid singular forms`,
+              currentValue: invalidSingularForms.map(f => f.form_text),
+              expectedValue: 'Only plural forms allowed for reciprocal usage',
+              manualSteps: [
+                'Remove singular forms from reciprocal translation',
+                'Ensure only noi/voi/loro persons are linked to reciprocal meanings'
+              ],
+              epicContext: 'Reciprocal actions require multiple actors (plural only)'
+            });
+          }
+        }
+      });
 
       this.calculateVerbCompliance(report);
 


### PR DESCRIPTION
## Summary
- calculate expected forms for reciprocal translations and detect reciprocal/reflexive metadata
- adjust translation coverage and validation rules for plural-only reciprocal forms
- surface reciprocal/reflexive badges and coverage details in admin interface

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68983089156083299146fd8aec161283