### PR TITLE
Enhance optional tag display names

### DIFF
--- a/app/admin/migration-tools/components/SearchInterface.tsx
+++ b/app/admin/migration-tools/components/SearchInterface.tsx
@@ -6,6 +6,7 @@ import { MetavalService, MetaAttribute, MetaValue } from '../services/MetavalSer
 import RuleBuilder from './RuleBuilder';
 import { useState as useInternalState, useEffect as useInternalEffect } from 'react';
 import { CoreTagDisplay, OptionalTagDisplay, AttributeNameDisplay, BatchTagDisplay } from './TagDisplayComponents';
+import { DisplayNameService } from '../utils/DisplayNameUtils';
 
 // Note: CoreTagDisplay and OptionalTagDisplay components are now imported from TagDisplayComponents.tsx
 // This provides optimized display with centralized caching and proper value stable ID support
@@ -175,11 +176,39 @@ export default function SearchInterface({ state, actions, handlers, dbService }:
   };
 
   // Enhance optional tags with metaval display names if applicable
-  const enhanceOptionalTagsWithDisplayNames = async (optionalTags: { tag: string; count: number; tables: string[] }[]) => {
-    return optionalTags.map(tagData => ({
-      ...tagData,
-      displayName: tagData.tag // Optional tags typically show as-is
-    }));
+  const enhanceOptionalTagsWithDisplayNames = async (
+    optionalTags: { tag: string; count: number; tables: string[] }[]
+  ) => {
+    const displayService = DisplayNameService.getInstance();
+    const cache = new Map<string, string>();
+
+    return Promise.all(
+      optionalTags.map(async (tagData) => {
+        let displayName = tagData.tag;
+
+        if (tagData.tag.match(/^metaattr\d+val\d+$/)) {
+          if (cache.has(tagData.tag)) {
+            displayName = cache.get(tagData.tag)!;
+          } else {
+            try {
+              const name = await displayService.getValueDisplayName(tagData.tag);
+              cache.set(tagData.tag, name);
+              displayName = name;
+            } catch (error) {
+              console.warn(
+                `Failed to get display name for optional tag ${tagData.tag}:`,
+                error
+              );
+            }
+          }
+        }
+
+        return {
+          ...tagData,
+          displayName,
+        };
+      })
+    );
   };
 
   // Load available words


### PR DESCRIPTION
## Summary
- Enhance optional tag labels by detecting metaattr stable IDs and querying DisplayNameService
- Cache optional tag display names to avoid redundant lookups

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'lucide-react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b19c6368808329a5e2fa88abb4ecd8