### PR TITLE
Improve display name resolution for stable IDs

### DIFF
--- a/app/admin/migration-tools/components/RuleBuilder.tsx
+++ b/app/admin/migration-tools/components/RuleBuilder.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { useState, useEffect } from 'react'
 import { MetavalService, ValidationResult } from '../services/MetavalService'
 import { DatabaseService } from '../services/DatabaseService'
+import { DisplayNameService } from '../utils/DisplayNameUtils'
 
 // ============================================================================
 // ULTRA-DESIGNED RULE BUILDER INTERFACE
@@ -320,6 +321,56 @@ export default function RuleBuilder({
   // METAVAL: Get display name for attribute with fallback
   const getAttributeDisplayName = (attr: string): string => {
     return metavalState.attributeDisplayNames[attr] || attr
+  }
+
+  const displayService = DisplayNameService.getInstance()
+  const [currentValueDisplayNames, setCurrentValueDisplayNames] = useState<Record<string, string>>({})
+
+  const getCurrentValueDisplayName = (recordId: string, metadataKey: string): string => {
+    const cacheKey = `${recordId}_${metadataKey}`
+    if (currentValueDisplayNames[cacheKey]) {
+      return currentValueDisplayNames[cacheKey]
+    }
+
+    let value: string | null = null
+    for (const hierarchy of Object.values(wordHierarchies)) {
+      let record = null
+      if (hierarchy.word.id === recordId) record = hierarchy.word
+      else record = [...hierarchy.forms, ...hierarchy.translations, ...hierarchy.formTranslations].find(r => r.id === recordId)
+
+      if (record && 'metadata' in record && (record as any).metadata && (record as any).metadata[metadataKey]) {
+        value = (record as any).metadata[metadataKey]
+        break
+      }
+    }
+
+    if (!value) {
+      setCurrentValueDisplayNames(prev => ({ ...prev, [cacheKey]: 'unknown' }))
+      return 'unknown'
+    }
+
+    if (!value.match(/^metaattr\d+val\d+$/)) {
+      setCurrentValueDisplayNames(prev => ({ ...prev, [cacheKey]: value! }))
+      return value
+    }
+
+    displayService
+      .getValueDisplayName(value)
+      .then(res => {
+        setCurrentValueDisplayNames(prev => ({
+          ...prev,
+          [cacheKey]: res.resolved ? res.displayName : `${res.displayName} (ID)`
+        }))
+        if (!res.resolved) {
+          console.warn(`RuleBuilder: Falling back to stable ID for value ${value}`)
+        }
+      })
+      .catch(error => {
+        console.warn(`RuleBuilder: Failed to resolve value ${value}:`, error)
+        setCurrentValueDisplayNames(prev => ({ ...prev, [cacheKey]: value! }))
+      })
+
+    return '…'
   }
 
   // METAVAL: Check if attribute has validation errors
@@ -828,20 +879,7 @@ export default function RuleBuilder({
                               <div className="text-xs w-20">
                                 <div className="text-gray-500 text-[10px] mb-1">Current</div>
                                 <span className="bg-blue-100 text-blue-700 px-2 py-1 rounded text-xs block w-full truncate">
-                                {(() => {
-                                  // Extract just the current value from the record data
-                                  for (const hierarchy of Object.values(wordHierarchies)) {
-                                    let record = null
-                                    if (hierarchy.word.id === recordId) record = hierarchy.word
-                                    else record = [...hierarchy.forms, ...hierarchy.translations, ...hierarchy.formTranslations]
-                                      .find(r => r.id === recordId)
-                                    
-                                    if (record && 'metadata' in record && (record as any).metadata && (record as any).metadata[metadataKey]) {
-                                      return (record as any).metadata[metadataKey]
-                                    }
-                                  }
-                                  return 'unknown'
-                                })()}
+                                  {getCurrentValueDisplayName(recordId, metadataKey)}
                                 </span>
                               </div>
                               

--- a/app/admin/migration-tools/components/RuleBuilder.tsx
+++ b/app/admin/migration-tools/components/RuleBuilder.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from 'react'
 import { MetavalService, ValidationResult } from '../services/MetavalService'
 import { DatabaseService } from '../services/DatabaseService'
 import { DisplayNameService } from '../utils/DisplayNameUtils'
+import { OptionalTagDisplay } from './TagDisplayComponents'
 
 // ============================================================================
 // ULTRA-DESIGNED RULE BUILDER INTERFACE
@@ -959,9 +960,9 @@ export default function RuleBuilder({
                             
                             return (
                             <div key={tagKey} className="flex items-center space-x-3 mb-2 ml-4">
-                              <span className="bg-green-100 text-green-700 px-2 py-1 rounded text-xs min-w-[120px]">
-                                {tagValue}
-                              </span>
+                              <div className="min-w-[120px]">
+                                <OptionalTagDisplay tag={tagValue} />
+                              </div>
                               
                               <select
                                 value={config.action}

--- a/app/admin/migration-tools/components/RuleBuilder.tsx
+++ b/app/admin/migration-tools/components/RuleBuilder.tsx
@@ -319,13 +319,45 @@ export default function RuleBuilder({
     }
   }
 
-  // METAVAL: Get display name for attribute with fallback
-  const getAttributeDisplayName = (attr: string): string => {
-    return metavalState.attributeDisplayNames[attr] || attr
-  }
-
   const displayService = DisplayNameService.getInstance()
+  const [attributeDisplayNameCache, setAttributeDisplayNameCache] = useState<Record<string, string>>({})
   const [currentValueDisplayNames, setCurrentValueDisplayNames] = useState<Record<string, string>>({})
+
+  // METAVAL: Get display name for attribute with fallback and caching
+  const getAttributeDisplayName = (attr: string): string => {
+    if (attributeDisplayNameCache[attr]) {
+      return attributeDisplayNameCache[attr]
+    }
+
+    if (metavalState.attributeDisplayNames[attr]) {
+      const name = metavalState.attributeDisplayNames[attr]
+      setAttributeDisplayNameCache(prev => ({ ...prev, [attr]: name }))
+      return name
+    }
+
+    if (attr.startsWith('metaattr')) {
+      displayService
+        .getAttributeDisplayName(attr)
+        .then(res => {
+          setAttributeDisplayNameCache(prev => ({
+            ...prev,
+            [attr]: res.resolved ? res.displayName : `${res.displayName} (ID)`
+          }))
+          if (!res.resolved) {
+            console.warn(`RuleBuilder: Falling back to attribute ID ${attr}`)
+          }
+        })
+        .catch(error => console.warn(`RuleBuilder: Failed to resolve attribute ${attr}:`, error))
+      return attr
+    }
+
+    const formatted = attr
+      .split('_')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ')
+    setAttributeDisplayNameCache(prev => ({ ...prev, [attr]: formatted }))
+    return formatted
+  }
 
   const getCurrentValueDisplayName = (recordId: string, metadataKey: string): string => {
     const cacheKey = `${recordId}_${metadataKey}`

--- a/app/admin/migration-tools/components/SearchInterface.tsx
+++ b/app/admin/migration-tools/components/SearchInterface.tsx
@@ -46,6 +46,7 @@ export default function SearchInterface({ state, actions, handlers, dbService }:
     coreTags: string[];
     optionalTags: string[];
   }>({ coreTags: [], optionalTags: [] });
+  const [selectedTagDisplayNames, setSelectedTagDisplayNames] = useState<Record<string, string>>({});
   
   const [contentTypes] = useState(['Dictionary Words', 'Conjugated Forms', 'English Translations', 'Form Translations']);
   const [selectedContentTypes, setSelectedContentTypes] = useState<string[]>(['Dictionary Words', 'Conjugated Forms', 'English Translations', 'Form Translations']);
@@ -273,6 +274,72 @@ export default function SearchInterface({ state, actions, handlers, dbService }:
       }));
     }
   };
+
+  // Resolve display names for selected tags
+  useEffect(() => {
+    const loadSelectedDisplayNames = async () => {
+      const service = DisplayNameService.getInstance();
+      const names: Record<string, string> = {};
+
+      await Promise.all(selectedTags.coreTags.map(async (tag) => {
+        const [attr, value] = tag.split(': ');
+        let attrName = attr;
+        let valueName = value;
+
+        if (attr.startsWith('metaattr')) {
+          try {
+            const res = await service.getAttributeDisplayName(attr);
+            attrName = res.resolved ? res.displayName : `${res.displayName} (ID)`;
+            if (!res.resolved) {
+              console.warn(`SearchInterface: Falling back to attribute ID for selected tag ${attr}`);
+            }
+          } catch (error) {
+            console.warn(`SearchInterface: Failed to resolve attribute ${attr}:`, error);
+          }
+        } else {
+          attrName = attr
+            .split('_')
+            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' ');
+        }
+
+        if (value.match(/^metaattr\d+val\d+$/)) {
+          try {
+            const res = await service.getValueDisplayName(value);
+            valueName = res.resolved ? res.displayName : `${res.displayName} (ID)`;
+            if (!res.resolved) {
+              console.warn(`SearchInterface: Falling back to value ID for selected tag ${value}`);
+            }
+          } catch (error) {
+            console.warn(`SearchInterface: Failed to resolve value ${value}:`, error);
+          }
+        }
+
+        names[tag] = `${attrName}: ${valueName}`;
+      }));
+
+      await Promise.all(selectedTags.optionalTags.map(async (tag) => {
+        if (tag.match(/^metaattr\d+val\d+$/)) {
+          try {
+            const res = await service.getValueDisplayName(tag);
+            names[tag] = res.resolved ? res.displayName : `${res.displayName} (ID)`;
+            if (!res.resolved) {
+              console.warn(`SearchInterface: Falling back to optional tag ID ${tag}`);
+            }
+          } catch (error) {
+            console.warn(`SearchInterface: Failed to resolve optional tag ${tag}:`, error);
+            names[tag] = tag;
+          }
+        } else {
+          names[tag] = tag;
+        }
+      }));
+
+      setSelectedTagDisplayNames(names);
+    };
+
+    loadSelectedDisplayNames();
+  }, [selectedTags]);
 
   // Toggle content type selection
   const toggleContentType = (contentType: string) => {
@@ -855,13 +922,13 @@ export default function SearchInterface({ state, actions, handlers, dbService }:
                     className="inline-flex items-center px-2 py-1 rounded-full text-xs bg-blue-100 text-blue-800 cursor-pointer hover:bg-blue-200"
                     onClick={() => toggleTag(tag, 'core')}
                   >
-                    {tag} ×
+                    {selectedTagDisplayNames[tag] || tag} ×
                   </span>
                 ))}
               </div>
             </div>
           )}
-          
+
           {selectedTags.optionalTags.length > 0 && (
             <div>
               <h4 className="text-sm font-medium text-gray-700 mb-1">🏷️ Selected Optional Tags:</h4>
@@ -872,7 +939,7 @@ export default function SearchInterface({ state, actions, handlers, dbService }:
                     className="inline-flex items-center px-2 py-1 rounded-full text-xs bg-green-100 text-green-800 cursor-pointer hover:bg-green-200"
                     onClick={() => toggleTag(tag, 'optional')}
                   >
-                    {tag} ×
+                    {selectedTagDisplayNames[tag] || tag} ×
                   </span>
                 ))}
               </div>

--- a/app/admin/migration-tools/components/SearchInterface.tsx
+++ b/app/admin/migration-tools/components/SearchInterface.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react';
 import { ModernDatabaseService, ModernSelectionCriteria } from '../services/ModernDatabaseService';
 import { MetavalService, MetaAttribute, MetaValue } from '../services/MetavalService';
 import RuleBuilder from './RuleBuilder';
-import { useState as useInternalState, useEffect as useInternalEffect } from 'react';
 import { CoreTagDisplay, OptionalTagDisplay, AttributeNameDisplay, BatchTagDisplay } from './TagDisplayComponents';
 import { DisplayNameService } from '../utils/DisplayNameUtils';
 

--- a/app/admin/migration-tools/components/SearchInterface.tsx
+++ b/app/admin/migration-tools/components/SearchInterface.tsx
@@ -6,6 +6,7 @@ import { MetavalService, MetaAttribute, MetaValue } from '../services/MetavalSer
 import RuleBuilder from './RuleBuilder';
 import { useState as useInternalState, useEffect as useInternalEffect } from 'react';
 import { CoreTagDisplay, OptionalTagDisplay, AttributeNameDisplay, BatchTagDisplay } from './TagDisplayComponents';
+import { DisplayNameService } from '../utils/DisplayNameUtils';
 
 // Note: CoreTagDisplay and OptionalTagDisplay components are now imported from TagDisplayComponents.tsx
 // This provides optimized display with centralized caching and proper value stable ID support
@@ -176,10 +177,24 @@ export default function SearchInterface({ state, actions, handlers, dbService }:
 
   // Enhance optional tags with metaval display names if applicable
   const enhanceOptionalTagsWithDisplayNames = async (optionalTags: { tag: string; count: number; tables: string[] }[]) => {
-    return optionalTags.map(tagData => ({
-      ...tagData,
-      displayName: tagData.tag // Optional tags typically show as-is
-    }));
+    const displayService = DisplayNameService.getInstance();
+    return Promise.all(
+      optionalTags.map(async tagData => {
+        let displayName = tagData.tag;
+        if (tagData.tag.match(/^metaattr\d+val\d+$/)) {
+          try {
+            const result = await displayService.getValueDisplayName(tagData.tag);
+            displayName = result.resolved ? result.displayName : `${result.displayName} (ID)`;
+            if (!result.resolved) {
+              console.warn(`SearchInterface: Falling back to stable ID for optional tag ${tagData.tag}`);
+            }
+          } catch (error) {
+            console.warn(`SearchInterface: Failed to get display name for optional tag ${tagData.tag}:`, error);
+          }
+        }
+        return { ...tagData, displayName };
+      })
+    );
   };
 
   // Load available words

--- a/app/admin/migration-tools/components/TagDisplayComponents.tsx
+++ b/app/admin/migration-tools/components/TagDisplayComponents.tsx
@@ -22,14 +22,18 @@ export function CoreTagDisplay({ attributeName, value }: {
         
         // Check if value looks like a stable ID (metaattrXXXvalYYY)
         if (value.match(/^metaattr\d+val\d+$/)) {
-          // Both attribute and value are stable IDs
-          const attrDisplayName = await displayService.getAttributeDisplayName(attributeName);
-          const valueDisplayName = await displayService.getValueDisplayName(value);
-          setDisplayText(`${attrDisplayName}: ${valueDisplayName}`);
+          const attrRes = await displayService.getAttributeDisplayName(attributeName);
+          const valRes = await displayService.getValueDisplayName(value);
+          setDisplayText(`${attrRes.resolved ? attrRes.displayName : `${attrRes.displayName} (ID)`}: ${valRes.resolved ? valRes.displayName : `${valRes.displayName} (ID)`}`);
+          if (!attrRes.resolved || !valRes.resolved) {
+            console.warn('CoreTagDisplay: Falling back to stable IDs', attributeName, value);
+          }
         } else if (attributeName.startsWith('metaattr')) {
-          // Only attribute is stable ID, value is plain text
-          const attrDisplayName = await displayService.getAttributeDisplayName(attributeName);
-          setDisplayText(`${attrDisplayName}: ${value}`);
+          const attrRes = await displayService.getAttributeDisplayName(attributeName);
+          setDisplayText(`${attrRes.resolved ? attrRes.displayName : `${attrRes.displayName} (ID)`}: ${value}`);
+          if (!attrRes.resolved) {
+            console.warn('CoreTagDisplay: Falling back to attribute ID', attributeName);
+          }
         } else {
           // Neither are stable IDs, format the attribute name and use value as-is
           const formattedAttrName = attributeName.split('_').map(word => 
@@ -79,8 +83,11 @@ export function ValueTagDisplay({ valueStableId }: { valueStableId: string }) {
     const loadValueDisplayName = async () => {
       setIsLoading(true);
       try {
-        const name = await displayService.getValueDisplayName(valueStableId);
-        setDisplayName(name);
+        const res = await displayService.getValueDisplayName(valueStableId);
+        setDisplayName(res.resolved ? res.displayName : `${res.displayName} (ID)`);
+        if (!res.resolved) {
+          console.warn('ValueTagDisplay: Falling back to stable ID', valueStableId);
+        }
       } catch (error) {
         console.warn('ValueTagDisplay: Failed to load value display name:', error);
         setDisplayName(valueStableId); // Fallback to stable ID
@@ -120,8 +127,11 @@ export function OptionalTagDisplay({ tag }: { tag: string }) {
       setIsLoading(true);
       const loadDisplayName = async () => {
         try {
-          const name = await displayService.getValueDisplayName(tag);
-          setDisplayName(name);
+          const res = await displayService.getValueDisplayName(tag);
+          setDisplayName(res.resolved ? res.displayName : `${res.displayName} (ID)`);
+          if (!res.resolved) {
+            console.warn('OptionalTagDisplay: Falling back to stable ID', tag);
+          }
         } catch (error) {
           console.warn('OptionalTagDisplay: Failed to enhance tag name:', error);
           // Keep original tag name
@@ -160,8 +170,11 @@ export function AttributeNameDisplay({
     const loadDisplayName = async () => {
       setIsLoading(true);
       try {
-        const name = await getAttributeDisplayName(stableId);
-        setDisplayName(name);
+        const res = await getAttributeDisplayName(stableId);
+        setDisplayName(res.resolved ? res.displayName : `${res.displayName} (ID)`);
+        if (!res.resolved) {
+          console.warn('AttributeNameDisplay: Falling back to stable ID', stableId);
+        }
       } catch (error) {
         console.warn('AttributeNameDisplay: Failed to load display name:', error);
         // Keep fallback or stable ID

--- a/app/admin/migration-tools/utils/DisplayNameUtils.ts
+++ b/app/admin/migration-tools/utils/DisplayNameUtils.ts
@@ -9,13 +9,13 @@ export class DisplayNameService {
   private metavalService: MetavalService;
   
   // Caches
-  private attributeDisplayNames: Map<string, string> = new Map();
-  private valueDisplayNames: Map<string, string> = new Map();
+  private attributeDisplayNames: Map<string, { displayName: string; resolved: boolean }> = new Map();
+  private valueDisplayNames: Map<string, { displayName: string; resolved: boolean }> = new Map();
   private attributeToValues: Map<string, MetaValue[]> = new Map();
   
   // Pending requests to avoid duplicate calls
-  private pendingAttributeRequests: Map<string, Promise<string>> = new Map();
-  private pendingValueRequests: Map<string, Promise<string>> = new Map();
+  private pendingAttributeRequests: Map<string, Promise<{ displayName: string; resolved: boolean }>> = new Map();
+  private pendingValueRequests: Map<string, Promise<{ displayName: string; resolved: boolean }>> = new Map();
   
   private constructor() {
     this.metavalService = new MetavalService();
@@ -31,111 +31,99 @@ export class DisplayNameService {
   /**
    * Get display name for attribute stable ID (e.g., "metaattr008" -> "Gender")
    */
-  async getAttributeDisplayName(stableId: string): Promise<string> {
-    // Return cached result
+  async getAttributeDisplayName(stableId: string): Promise<{ displayName: string; resolved: boolean }> {
     if (this.attributeDisplayNames.has(stableId)) {
       return this.attributeDisplayNames.get(stableId)!;
     }
-    
-    // Return pending request if already in progress
+
     if (this.pendingAttributeRequests.has(stableId)) {
       return this.pendingAttributeRequests.get(stableId)!;
     }
-    
-    // Create new request
+
     const request = this.fetchAttributeDisplayName(stableId);
     this.pendingAttributeRequests.set(stableId, request);
-    
+
     const result = await request;
-    
-    // Clean up pending request
     this.pendingAttributeRequests.delete(stableId);
-    
+
     return result;
   }
-  
-  private async fetchAttributeDisplayName(stableId: string): Promise<string> {
+
+  private async fetchAttributeDisplayName(stableId: string): Promise<{ displayName: string; resolved: boolean }> {
     try {
       const attribute = await this.metavalService.getAttributeByStableId(stableId);
       let displayName: string;
-      
+      let resolved = true;
+
       if (attribute && attribute.display_name) {
         displayName = attribute.display_name;
       } else {
-        // Fallback to formatted technical name
         displayName = this.formatTechnicalName(stableId);
+        resolved = false;
+        console.warn(`DisplayNameService: Falling back to technical name for attribute ${stableId}`);
       }
-      
-      // Cache the result
-      this.attributeDisplayNames.set(stableId, displayName);
-      return displayName;
+
+      const result = { displayName, resolved };
+      this.attributeDisplayNames.set(stableId, result);
+      return result;
     } catch (error) {
       console.warn(`DisplayNameService: Failed to get attribute display name for ${stableId}:`, error);
       const fallback = this.formatTechnicalName(stableId);
-      this.attributeDisplayNames.set(stableId, fallback);
-      return fallback;
+      const result = { displayName: fallback, resolved: false };
+      this.attributeDisplayNames.set(stableId, result);
+      return result;
     }
   }
   
   /**
    * Get display name for value stable ID (e.g., "metaattr008val038" -> "Feminine")
    */
-  async getValueDisplayName(valueStableId: string): Promise<string> {
-    // Return cached result
+  async getValueDisplayName(valueStableId: string): Promise<{ displayName: string; resolved: boolean }> {
     if (this.valueDisplayNames.has(valueStableId)) {
       return this.valueDisplayNames.get(valueStableId)!;
     }
-    
-    // Return pending request if already in progress
+
     if (this.pendingValueRequests.has(valueStableId)) {
       return this.pendingValueRequests.get(valueStableId)!;
     }
-    
-    // Create new request
+
     const request = this.fetchValueDisplayName(valueStableId);
     this.pendingValueRequests.set(valueStableId, request);
-    
+
     const result = await request;
-    
-    // Clean up pending request
     this.pendingValueRequests.delete(valueStableId);
-    
+
     return result;
   }
-  
-  private async fetchValueDisplayName(valueStableId: string): Promise<string> {
+
+  private async fetchValueDisplayName(valueStableId: string): Promise<{ displayName: string; resolved: boolean }> {
     try {
-      // Try to find the value by searching through attributes
-      // Value stable IDs typically follow pattern: attributeStableId + "val" + number
-      // e.g., "metaattr008val038" where "metaattr008" is the attribute stable ID
-      
       const attributeStableId = this.extractAttributeStableId(valueStableId);
-      
+
       if (attributeStableId) {
-        // Get values for this attribute
         let values = this.attributeToValues.get(attributeStableId);
-        
+
         if (!values) {
           values = await this.metavalService.getValuesByStableId(attributeStableId);
           this.attributeToValues.set(attributeStableId, values);
         }
-        
-        // Find the specific value
+
         const value = values.find(v => v.stable_id === valueStableId);
         if (value) {
           const displayName = value.shorthand || value.value;
-          this.valueDisplayNames.set(valueStableId, displayName);
-          return displayName;
+          const result = { displayName, resolved: true };
+          this.valueDisplayNames.set(valueStableId, result);
+          return result;
         }
       }
-      
-      // Fallback to the stable ID itself
-      const fallback = valueStableId;
+
+      console.warn(`DisplayNameService: Falling back to stable ID for value ${valueStableId}`);
+      const fallback = { displayName: valueStableId, resolved: false };
       this.valueDisplayNames.set(valueStableId, fallback);
       return fallback;
     } catch (error) {
       console.warn(`DisplayNameService: Failed to get value display name for ${valueStableId}:`, error);
-      const fallback = valueStableId;
+      const fallback = { displayName: valueStableId, resolved: false };
       this.valueDisplayNames.set(valueStableId, fallback);
       return fallback;
     }
@@ -159,8 +147,8 @@ export class DisplayNameService {
       this.getAttributeDisplayName(attributeStableId),
       this.getValueDisplayName(valueStableId)
     ]);
-    
-    return `${attributeName}: ${valueName}`;
+
+    return `${attributeName.displayName}: ${valueName.displayName}`;
   }
   
   /**
@@ -168,7 +156,7 @@ export class DisplayNameService {
    */
   async batchGetAttributeDisplayNames(stableIds: string[]): Promise<Map<string, string>> {
     const promises = stableIds.map(id => 
-      this.getAttributeDisplayName(id).then(name => [id, name] as [string, string])
+      this.getAttributeDisplayName(id).then(res => [id, res.displayName] as [string, string])
     );
     
     const results = await Promise.all(promises);
@@ -180,7 +168,7 @@ export class DisplayNameService {
    */
   async batchGetValueDisplayNames(stableIds: string[]): Promise<Map<string, string>> {
     const promises = stableIds.map(id => 
-      this.getValueDisplayName(id).then(name => [id, name] as [string, string])
+      this.getValueDisplayName(id).then(res => [id, res.displayName] as [string, string])
     );
     
     const results = await Promise.all(promises);


### PR DESCRIPTION
## Summary
- add resolution status and warnings to DisplayNameService
- translate optional tag stable IDs into readable names in SearchInterface
- show resolved metadata values in RuleBuilder and tag display components

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fauth-helpers-nextjs)*
- `npm run build` *(fails: Module not found: Can't resolve '@supabase/auth-helpers-nextjs')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b194bb5cc8832994ecce2bc44a3d6c