### PR TITLE
Word card chip coverage parity

### DIFF
--- a/components/AudioButton.js
+++ b/components/AudioButton.js
@@ -33,8 +33,11 @@ export default function AudioButton({
     md: 'w-7 h-7', 
     lg: 'w-8 h-8',
     xl: 'w-10 h-10',
-    chip: 'w-8 h-8'
+    chip: 'w-8 h-8',
+    inline: 'w-5 h-5'
   }
+
+  const isInlineIcon = variant === 'inline-icon'
 
   // Handle audio playback
   const handlePlay = async () => {
@@ -67,22 +70,26 @@ export default function AudioButton({
       disabled={isPlaying}
       aria-label={buttonTitle}
       className={`
-        ${sizeClasses[size] || sizeClasses.md}
-        text-white rounded-full
+        ${sizeClasses[isInlineIcon ? 'inline' : size] || sizeClasses.md}
+        ${isInlineIcon ? 'rounded-none bg-transparent' : 'text-white rounded-full'}
         flex items-center justify-center
         transition-all duration-200
         flex-shrink-0
-        ${hasPremiumAudio ? 'premium-audio border-2 border-yellow-400 shadow-lg' : ''}
+        ${isInlineIcon ? '' : hasPremiumAudio ? 'premium-audio border-2 border-yellow-400 shadow-lg' : ''}
         ${isPlaying ? 'opacity-75 cursor-not-allowed' : 'hover:scale-105'}
-        ${colorClass}
-        ${isError ? 'bg-red-500 hover:bg-red-600' : ''}
+        ${isInlineIcon
+          ? hasPremiumAudio
+            ? 'text-amber-500 hover:text-amber-600'
+            : 'text-teal-600 hover:text-teal-700'
+          : colorClass}
+        ${isError ? (isInlineIcon ? 'text-red-500 hover:text-red-600' : 'bg-red-500 hover:bg-red-600') : ''}
         ${className}
       `}
       title={buttonTitle}
     >
       {isPlaying ? (
         <svg 
-          className="animate-spin h-3 w-3 text-white" 
+          className={`animate-spin ${isInlineIcon ? 'h-4 w-4' : 'h-3 w-3'} ${isInlineIcon ? '' : 'text-white'}`}
           xmlns="http://www.w3.org/2000/svg" 
           fill="none" 
           viewBox="0 0 24 24"
@@ -102,30 +109,28 @@ export default function AudioButton({
           />
         </svg>
       ) : isError ? (
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+        <svg width={isInlineIcon ? '16' : '12'} height={isInlineIcon ? '16' : '12'} viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"/>
         </svg>
       ) : (
-        <>
-          <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
-            <path
-              d="M3.5 8H6.2L10.8 4.6V15.4L6.2 12H3.5V8Z"
-              fill="currentColor"
-            />
-            <path
-              d="M13 8C13.9 8.65 14.35 9.35 14.35 10C14.35 10.65 13.9 11.35 13 12"
-              stroke="currentColor"
-              strokeWidth="2.2"
-              strokeLinecap="round"
-            />
-            <path
-              d="M15.1 6.3C16.45 7.35 17.15 8.55 17.15 10C17.15 11.45 16.45 12.65 15.1 13.7"
-              stroke="currentColor"
-              strokeWidth="2.2"
-              strokeLinecap="round"
-            />
-          </svg>
-        </>
+        <svg width={isInlineIcon ? '18' : '20'} height={isInlineIcon ? '18' : '20'} viewBox="0 0 20 20" fill="none">
+          <path
+            d="M3.5 8H6.2L10.8 4.6V15.4L6.2 12H3.5V8Z"
+            fill="currentColor"
+          />
+          <path
+            d="M13 8C13.9 8.65 14.35 9.35 14.35 10C14.35 10.65 13.9 11.35 13 12"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+          />
+          <path
+            d="M15.1 6.3C16.45 7.35 17.15 8.55 17.15 10C17.15 11.45 16.45 12.65 15.1 13.7"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+          />
+        </svg>
       )}
     </button>
   )

--- a/components/AudioButton.js
+++ b/components/AudioButton.js
@@ -34,7 +34,7 @@ export default function AudioButton({
     lg: 'w-8 h-8',
     xl: 'w-10 h-10',
     chip: 'w-8 h-8',
-    inline: 'w-5 h-5'
+    inline: 'w-8 h-8'
   }
 
   const isInlineIcon = variant === 'inline-icon'
@@ -89,7 +89,7 @@ export default function AudioButton({
     >
       {isPlaying ? (
         <svg 
-          className={`animate-spin ${isInlineIcon ? 'h-4 w-4' : 'h-3 w-3'} ${isInlineIcon ? '' : 'text-white'}`}
+          className={`animate-spin ${isInlineIcon ? 'h-7 w-7' : 'h-3 w-3'} ${isInlineIcon ? '' : 'text-white'}`}
           xmlns="http://www.w3.org/2000/svg" 
           fill="none" 
           viewBox="0 0 24 24"
@@ -109,11 +109,11 @@ export default function AudioButton({
           />
         </svg>
       ) : isError ? (
-        <svg width={isInlineIcon ? '16' : '12'} height={isInlineIcon ? '16' : '12'} viewBox="0 0 24 24" fill="currentColor">
+        <svg width={isInlineIcon ? '28' : '12'} height={isInlineIcon ? '28' : '12'} viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"/>
         </svg>
       ) : (
-        <svg width={isInlineIcon ? '18' : '20'} height={isInlineIcon ? '18' : '20'} viewBox="0 0 20 20" fill="none">
+        <svg width={isInlineIcon ? '30' : '20'} height={isInlineIcon ? '30' : '20'} viewBox="0 0 20 20" fill="none">
           <path
             d="M3.5 8H6.2L10.8 4.6V15.4L6.2 12H3.5V8Z"
             fill="currentColor"

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -186,9 +186,9 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
         if (tierMap[normalizedValue]) {
           detailed.push({
             tag: `freq-tier-${normalizedValue}`,
-            display: `freq ${tierMap[normalizedValue]}`,
+            display: tierMap[normalizedValue],
             class: 'bg-yellow-500 text-white',
-            description: `Frequency tier: pedagogical band derived from corpus rank (${tierMap[normalizedValue]})`
+            description: `Frequency tier: ${tierMap[normalizedValue]}. This is a broad learning-priority band derived from corpus frequency`
           })
         }
       }
@@ -567,28 +567,28 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       else if (attributeStableId === 'metaattr061') {
         const determinerTypeMap = {
           'article': {
-            display: 'det article',
-            description: 'Determiner type: article determiner'
+            display: 'article det.',
+            description: 'Determiner type: article. It marks definiteness or indefiniteness of a noun phrase'
           },
           'demonstrative': {
-            display: 'det demonstr.',
-            description: 'Determiner type: points to a specific referent (this/that)'
+            display: 'demonstr. det.',
+            description: 'Determiner type: demonstrative. It points to a specific referent (this/that)'
           },
           'indefinite-article': {
-            display: 'det indef.',
-            description: 'Determiner type: introduces a non-specific referent'
+            display: 'indef. det.',
+            description: 'Determiner type: indefinite article. It introduces a non-specific referent'
           },
           'interrogative': {
-            display: 'det interrog.',
-            description: 'Determiner type: used to ask which/what/how many'
+            display: 'interrog. det.',
+            description: 'Determiner type: interrogative. It is used to ask which/what/how many'
           },
           'possessive': {
-            display: 'det possess.',
-            description: 'Determiner type: marks possession/association'
+            display: 'possess. det.',
+            description: 'Determiner type: possessive. It marks possession or association'
           },
           'quantifier': {
-            display: 'det quant.',
-            description: 'Determiner type: expresses quantity or amount'
+            display: 'quant. det.',
+            description: 'Determiner type: quantifier. It expresses amount or quantity'
           }
         }
         if (determinerTypeMap[normalizedValue]) {
@@ -647,20 +647,20 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       else if (attributeStableId === 'metaattr041') {
         const pronounFormMap = {
           'full': {
-            display: 'form full',
-            description: 'Pronoun form: full standalone pronoun form'
+            display: 'full form',
+            description: 'Pronoun form: full standalone form. It appears independently, not attached to a verb'
           },
           'clitic': {
-            display: 'form clitic',
-            description: 'Pronoun form: clitic form that attaches to a verb'
+            display: 'clitic form',
+            description: 'Pronoun form: clitic. It is a reduced form that attaches to a verb'
           },
           'combined': {
-            display: 'form combined',
-            description: 'Pronoun form: combined clitic cluster'
+            display: 'combined form',
+            description: 'Pronoun form: combined clitic cluster (two clitics fused into one sequence)'
           },
           'elision': {
-            display: 'form elision',
-            description: 'Pronoun form: elided form with apostrophe'
+            display: 'elided form',
+            description: 'Pronoun form: elided. The pronoun is shortened before a vowel, often with an apostrophe'
           }
         }
         if (pronounFormMap[normalizedValue]) {
@@ -675,24 +675,24 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       else if (attributeStableId === 'metaattr040') {
         const pronounTypeMap = {
           'personal': {
-            display: 'pron personal',
-            description: 'Pronoun type: personal pronoun'
+            display: 'personal pron.',
+            description: 'Pronoun type: personal pronoun, used for speaker/listener/third person reference'
           },
           'clitic': {
-            display: 'pron clitic',
-            description: 'Pronoun type: clitic-pronoun category'
+            display: 'clitic pron.',
+            description: 'Pronoun type: clitic pronoun category (object/reflexive clitic behavior)'
           },
           'indefinite': {
-            display: 'pron indef.',
-            description: 'Pronoun type: indefinite pronoun'
+            display: 'indef. pron.',
+            description: 'Pronoun type: indefinite pronoun, referring to non-specific people/things'
           },
           'relative': {
-            display: 'pron relative',
-            description: 'Pronoun type: relative pronoun introducing a relative clause'
+            display: 'relative pron.',
+            description: 'Pronoun type: relative pronoun that introduces a relative clause'
           },
           'demonstrative': {
-            display: 'pron demonstr.',
-            description: 'Pronoun type: demonstrative pronoun'
+            display: 'demonstr. pron.',
+            description: 'Pronoun type: demonstrative pronoun pointing to a specific referent'
           }
         }
         if (pronounTypeMap[normalizedValue]) {
@@ -1349,36 +1349,36 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       } else if (attributeStableId === 'metaattr063') {
         const logicalRelationshipMap = {
           'addition': {
-            display: 'logic addition',
-            description: 'Logical relationship: adds information'
+            display: 'addition',
+            description: 'Logical relationship: adds information to the previous idea (e.g. and/also)'
           },
           'contrast': {
-            display: 'logic contrast',
-            description: 'Logical relationship: marks contrast/concession'
+            display: 'contrast',
+            description: 'Logical relationship: marks contrast or concession between ideas'
           },
           'disjunction': {
-            display: 'logic disjunction',
-            description: 'Logical relationship: presents alternatives'
+            display: 'disjunction',
+            description: 'Logical relationship: presents alternatives or choices'
           },
           'causal': {
-            display: 'logic causal',
-            description: 'Logical relationship: gives a reason/cause'
+            display: 'causal',
+            description: 'Logical relationship: introduces cause/reason'
           },
           'conditional': {
-            display: 'logic conditional',
-            description: 'Logical relationship: sets a condition'
+            display: 'conditional',
+            description: 'Logical relationship: introduces a condition'
           },
           'temporal': {
-            display: 'logic temporal',
-            description: 'Logical relationship: links events in time'
+            display: 'temporal',
+            description: 'Logical relationship: links events by time/sequence'
           },
           'purpose': {
-            display: 'logic purpose',
-            description: 'Logical relationship: indicates purpose'
+            display: 'purpose',
+            description: 'Logical relationship: indicates goal or purpose'
           },
           'relative': {
-            display: 'logic relative',
-            description: 'Logical relationship: relative-linking function'
+            display: 'relative (logic)',
+            description: 'Logical relationship: relative-linking function in discourse structure'
           }
         }
         if (logicalRelationshipMap[value]) {
@@ -1387,40 +1387,40 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       } else if (attributeStableId === 'metaattr021') {
         const verbTypeMap = {
           'defective-verb': {
-            display: 'verb defective',
-            description: 'Verb type: paradigm has missing standard forms'
+            display: 'defective',
+            description: 'Verb type: some standard forms are missing from the paradigm'
           },
           'impersonal-verb': {
-            display: 'verb impersonal',
-            description: 'Verb type: used mainly in impersonal constructions'
+            display: 'impersonal',
+            description: 'Verb type: used mainly in impersonal constructions, often third person'
           },
           'meteorological-verb': {
-            display: 'verb meteorol.',
-            description: 'Verb type: weather/meteorological usage'
+            display: 'meteorological',
+            description: 'Verb type: weather/meteorological usage (e.g. rain/snow patterns)'
           },
           'modal-verb': {
-            display: 'verb modal',
-            description: 'Verb type: modal verb used with infinitive complements'
+            display: 'modal',
+            description: 'Verb type: modal verb, typically combining with an infinitive'
           },
           'direct-reflexive': {
-            display: 'verb dir-refl',
-            description: 'Verb type: direct reflexive meaning is central'
+            display: 'direct reflexive',
+            description: 'Verb type: direct reflexive meaning is central for this sense'
           },
           'reciprocal': {
-            display: 'verb reciprocal',
-            description: 'Verb type: reciprocal (mutual action) sense'
+            display: 'reciprocal',
+            description: 'Verb type: reciprocal sense where participants act on each other'
           },
           'pronominal-variant': {
-            display: 'verb pronominal',
-            description: 'Verb type: pronominal variant with fixed particles/clitics'
+            display: 'pronominal',
+            description: 'Verb type: pronominal variant with fixed clitic/particle behavior'
           },
           'transitive-verb': {
-            display: 'verb transitive',
-            description: 'Verb type: transitive verb class'
+            display: 'transitive',
+            description: 'Verb type: transitive class'
           },
           'intransitive-verb': {
-            display: 'verb intransitive',
-            description: 'Verb type: intransitive verb class'
+            display: 'intransitive',
+            description: 'Verb type: intransitive class'
           }
         }
         if (verbTypeMap[value]) {
@@ -1429,35 +1429,35 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       } else if (attributeStableId === 'metaattr013') {
         const wordRestrictionMap = {
           'invariable': {
-            display: 'restriction invar',
-            description: 'Word restriction: invariable usage in this sense/context'
+            display: 'invariable',
+            description: 'Word restriction: this sense behaves as invariable in context'
           },
           'plural-only': {
-            display: 'restriction plural',
-            description: 'Word restriction: used only in plural'
+            display: 'plural only',
+            description: 'Word restriction: used only in plural forms'
           },
           'only-plural': {
-            display: 'restriction plural',
-            description: 'Word restriction: used only in plural'
+            display: 'plural only',
+            description: 'Word restriction: used only in plural forms'
           },
           'singular-only': {
-            display: 'restriction singular',
-            description: 'Word restriction: used only in singular'
+            display: 'singular only',
+            description: 'Word restriction: used only in singular forms'
           },
           'third-person-only': {
-            display: 'restriction 3rd',
+            display: '3rd person only',
             description: 'Word restriction: only third-person forms are used'
           },
           'third-singular-only': {
-            display: 'restriction 3sg',
+            display: '3rd singular only',
             description: 'Word restriction: only third-person singular is used'
           },
           'missing-first-second-person': {
-            display: 'restriction no 1st/2nd',
-            description: 'Word restriction: first/second person forms are not used'
+            display: 'no 1st/2nd person',
+            description: 'Word restriction: first and second person forms are not used'
           },
           'missing-imperative': {
-            display: 'restriction no imp.',
+            display: 'no imperative',
             description: 'Word restriction: imperative forms are not used'
           }
         }

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -54,13 +54,28 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
   }
 
   // Process RPC tags for display - Comprehensive mapping of all original tags
-  const processRpcTagsForDisplay = (coreTags, wordType) => {
+  const processRpcTagsForDisplay = (coreTags, wordType, optionalTags = []) => {
     const essential = []
     const detailed = []
 
     if (!Array.isArray(coreTags)) {
       return { essential, detailed }
     }
+
+    const normalizeValue = (value) => String(value || '').trim().toLowerCase()
+    const formatSlugLabel = (value) =>
+      String(value || '')
+        .replace(/[_-]+/g, ' ')
+        .trim()
+
+    const wordThemeClass =
+      wordType === 'VERB'
+        ? 'bg-teal-500 text-white'
+        : wordType === 'ADJECTIVE'
+          ? 'bg-blue-500 text-white'
+          : wordType === 'ADVERB'
+            ? 'bg-purple-500 text-white'
+            : 'bg-cyan-500 text-white'
     
     // Track number restrictions to implement hierarchical display
     const hasNumberRestrictions = coreTags.some(tag => isAttribute(tag, ATTRIBUTES.NUMBER_RESTRICTION))
@@ -116,6 +131,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     coreTags.forEach(tag => {
       const valueId = tag.value_id
       const valueLabel = tag.value_label || ''
+      const normalizedValue = normalizeValue(valueLabel)
       const attributeStableId = tag.attribute_stable_id
       
       
@@ -138,8 +154,8 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
         }
       }
 
-      // FREQUENCY TIER MAPPING (essential)
-      else if (isAttribute(tag, ATTRIBUTES.FREQUENCY_TIER)) {
+      // FREQUENCY RANK MAPPING (essential)
+      else if (isAttribute(tag, ATTRIBUTES.FREQUENCY_TIER) || attributeStableId === 'metaattr007') {
         const freqMap = {
           'top100': '100',
           'top500': '500', 
@@ -148,12 +164,31 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
           'top5000': '5K',
           'top10000': '10K'
         }
-        if (freqMap[valueLabel]) {
+        if (freqMap[normalizedValue]) {
           essential.push({
-            tag: `freq-${valueLabel}`,
-            display: `⭐ ${freqMap[valueLabel]}`,
+            tag: `freq-rank-${normalizedValue}`,
+            display: `⭐ ${freqMap[normalizedValue]}`,
             class: 'bg-yellow-500 text-white',
-            description: `Top ${valueLabel.replace('top', '').replace('10000', '10,000')} most frequent words`
+            description: `Top ${normalizedValue.replace('top', '').replace('10000', '10,000')} most frequent words`
+          })
+        }
+      }
+
+      // FREQUENCY TIER MAPPING (detailed)
+      else if (attributeStableId === 'metaattr034') {
+        const tierMap = {
+          'very-common': 'very common',
+          'common': 'common',
+          'uncommon': 'uncommon',
+          'rare': 'rare',
+          'very-rare': 'very rare'
+        }
+        if (tierMap[normalizedValue]) {
+          detailed.push({
+            tag: `freq-tier-${normalizedValue}`,
+            display: tierMap[normalizedValue],
+            class: 'bg-yellow-500 text-white',
+            description: `Frequency tier: ${tierMap[normalizedValue]}`
           })
         }
       }
@@ -187,14 +222,14 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       // NUMBER MAPPING (essential for nouns at word-level)
       // Skip if number restrictions exist (hierarchical priority)
       else if (isAttribute(tag, ATTRIBUTES.NUMBER) && wordType === 'NOUN' && !hasNumberRestrictions) {
-        if (valueLabel === 'singolare') {
+        if (normalizedValue === 'singolare' || normalizedValue === 'singular') {
           essential.push({
             tag: 'singolare',
             display: 'sing.',
             class: 'bg-cyan-500 text-white', // NOUN theme
             description: 'Singular number form'
           })
-        } else if (valueLabel === 'plurale') {
+        } else if (normalizedValue === 'plurale' || normalizedValue === 'plural') {
           essential.push({
             tag: 'plurale',
             display: 'pl.',
@@ -243,6 +278,13 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             display: '2F',
             class: 'bg-blue-500 text-white', // ADJECTIVE theme
             description: 'Form pattern - Limited agreement: grande/grandi'
+          })
+        } else if (valueLabel === 'form-invariable') {
+          detailed.push({
+            tag: 'form-invariable',
+            display: 'INV',
+            class: 'bg-blue-500 text-white', // ADJECTIVE theme
+            description: 'Form pattern - Invariable adjective form'
           })
         }
       }
@@ -308,19 +350,54 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
 
       // REGISTER MAPPING (only show non-neutral)
       else if (isAttribute(tag, ATTRIBUTES.REGISTER)) {
-        if (valueLabel === 'formal') {
+        if (normalizedValue === 'formal') {
           detailed.push({
             tag: 'formal-register',
             display: 'formal',
             class: 'bg-gray-500 text-white', // Register is universal
             description: 'Formal contexts only'
           })
-        } else if (valueLabel === 'casual') {
+        } else if (normalizedValue === 'casual') {
           detailed.push({
             tag: 'casual-register', 
             display: 'casual',
             class: 'bg-gray-500 text-white', // Register is universal
             description: 'Casual/colloquial usage'
+          })
+        } else if (normalizedValue === 'archaic') {
+          detailed.push({
+            tag: 'archaic-register',
+            display: 'archaic',
+            class: 'bg-gray-500 text-white',
+            description: 'Archaic register'
+          })
+        } else if (normalizedValue === 'informal') {
+          detailed.push({
+            tag: 'informal-register',
+            display: 'informal',
+            class: 'bg-gray-500 text-white',
+            description: 'Informal register'
+          })
+        } else if (normalizedValue === 'literary') {
+          detailed.push({
+            tag: 'literary-register',
+            display: 'literary',
+            class: 'bg-gray-500 text-white',
+            description: 'Literary register'
+          })
+        } else if (normalizedValue === 'regional') {
+          detailed.push({
+            tag: 'regional-register',
+            display: 'regional',
+            class: 'bg-gray-500 text-white',
+            description: 'Regional register'
+          })
+        } else if (normalizedValue === 'vulgar') {
+          detailed.push({
+            tag: 'vulgar-register',
+            display: 'vulgar',
+            class: 'bg-gray-500 text-white',
+            description: 'Vulgar register'
           })
         }
         // Skip 'neutral' register - don't display
@@ -379,6 +456,180 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             display: 'plural-i',
             class: 'bg-cyan-500 text-white', // NOUN theme
             description: 'Forms plural by changing -o to -i (libro → libri)'
+          })
+        } else if (valueLabel === 'plural-e-to-i') {
+          detailed.push({
+            tag: 'plural-formation-e-to-i',
+            display: 'plural e→i',
+            class: 'bg-cyan-500 text-white',
+            description: 'Forms plural by changing -e to -i'
+          })
+        } else if (valueLabel === 'plural-invariable') {
+          detailed.push({
+            tag: 'plural-formation-invariable',
+            display: 'plural inv.',
+            class: 'bg-cyan-500 text-white',
+            description: 'Invariable plural form'
+          })
+        } else if (valueLabel === 'plural-irregular') {
+          detailed.push({
+            tag: 'plural-formation-irregular',
+            display: 'plural irreg.',
+            class: 'bg-cyan-500 text-white',
+            description: 'Irregular plural formation'
+          })
+        }
+      }
+      else if (attributeStableId === 'metaattr030') {
+        const adjectiveTypeMap = {
+          'qualitative': 'qualitative',
+          'fixed-comparative': 'fixed comp.',
+          'relational': 'relational'
+        }
+        if (adjectiveTypeMap[normalizedValue]) {
+          detailed.push({
+            tag: `adjective-type-${normalizedValue}`,
+            display: adjectiveTypeMap[normalizedValue],
+            class: wordThemeClass,
+            description: `Adjective type: ${adjectiveTypeMap[normalizedValue]}`
+          })
+        }
+      }
+      else if (attributeStableId === 'metaattr_matrix5_abbreviation_type') {
+        const abbreviationTypeMap = {
+          'initialism': 'initialism',
+          'acronym': 'acronym'
+        }
+        if (abbreviationTypeMap[normalizedValue]) {
+          detailed.push({
+            tag: `abbreviation-type-${normalizedValue}`,
+            display: abbreviationTypeMap[normalizedValue],
+            class: wordThemeClass,
+            description: `Abbreviation type: ${abbreviationTypeMap[normalizedValue]}`
+          })
+        }
+      }
+      else if (attributeStableId === 'metaattr_matrix5_affix_type') {
+        const affixTypeMap = {
+          'prefix': 'prefix'
+        }
+        if (affixTypeMap[normalizedValue]) {
+          detailed.push({
+            tag: `affix-type-${normalizedValue}`,
+            display: affixTypeMap[normalizedValue],
+            class: wordThemeClass,
+            description: `Affix type: ${affixTypeMap[normalizedValue]}`
+          })
+        }
+      }
+      else if (attributeStableId === 'metaattr062') {
+        const conjunctionTypeMap = {
+          'coordinating': 'coord.',
+          'subordinating': 'subord.',
+          'correlative': 'correl.'
+        }
+        if (conjunctionTypeMap[normalizedValue]) {
+          detailed.push({
+            tag: `conjunction-type-${normalizedValue}`,
+            display: conjunctionTypeMap[normalizedValue],
+            class: wordThemeClass,
+            description: `Conjunction type: ${formatSlugLabel(normalizedValue)}`
+          })
+        }
+      }
+      else if (attributeStableId === 'metaattr061') {
+        const determinerTypeMap = {
+          'article': 'article',
+          'demonstrative': 'demonstrative',
+          'indefinite-article': 'indef. article',
+          'interrogative': 'interrogative',
+          'possessive': 'possessive',
+          'quantifier': 'quantifier'
+        }
+        if (determinerTypeMap[normalizedValue]) {
+          detailed.push({
+            tag: `determiner-type-${normalizedValue}`,
+            display: determinerTypeMap[normalizedValue],
+            class: wordThemeClass,
+            description: `Determiner type: ${determinerTypeMap[normalizedValue]}`
+          })
+        }
+      }
+      else if (attributeStableId === 'metaattr069') {
+        const expressionTypeMap = {
+          'single-word': 'single word',
+          'multiword-expression': 'multiword'
+        }
+        if (expressionTypeMap[normalizedValue]) {
+          detailed.push({
+            tag: `expression-type-${normalizedValue}`,
+            display: expressionTypeMap[normalizedValue],
+            class: wordThemeClass,
+            description: `Expression type: ${expressionTypeMap[normalizedValue]}`
+          })
+        }
+      }
+      else if (attributeStableId === 'metaattr060') {
+        const prepositionTypeMap = {
+          'simple': 'simple prep.',
+          'complex': 'complex prep.',
+          'contracted': 'contracted prep.'
+        }
+        if (prepositionTypeMap[normalizedValue]) {
+          detailed.push({
+            tag: `preposition-type-${normalizedValue}`,
+            display: prepositionTypeMap[normalizedValue],
+            class: wordThemeClass,
+            description: `Preposition type: ${formatSlugLabel(normalizedValue)}`
+          })
+        }
+      }
+      else if (attributeStableId === 'metaattr041') {
+        const pronounFormMap = {
+          'full': 'full pron.',
+          'clitic': 'clitic pron.',
+          'combined': 'combined pron.',
+          'elision': 'elided pron.'
+        }
+        if (pronounFormMap[normalizedValue]) {
+          detailed.push({
+            tag: `pronoun-form-${normalizedValue}`,
+            display: pronounFormMap[normalizedValue],
+            class: wordThemeClass,
+            description: `Pronoun form: ${formatSlugLabel(normalizedValue)}`
+          })
+        }
+      }
+      else if (attributeStableId === 'metaattr040') {
+        const pronounTypeMap = {
+          'personal': 'personal pron.',
+          'clitic': 'clitic pron.',
+          'indefinite': 'indef. pron.',
+          'relative': 'relative pron.',
+          'demonstrative': 'demonstrative pron.'
+        }
+        if (pronounTypeMap[normalizedValue]) {
+          detailed.push({
+            tag: `pronoun-type-${normalizedValue}`,
+            display: pronounTypeMap[normalizedValue],
+            class: wordThemeClass,
+            description: `Pronoun type: ${formatSlugLabel(normalizedValue)}`
+          })
+        }
+      }
+      else if (attributeStableId === 'metaattr035') {
+        const phonologyPositionMap = {
+          'after-noun': 'post-nom.',
+          'before-most-consonants': 'pre consonant',
+          'before-impure-consonant': 'pre impure',
+          'before-vowel-or-h': 'pre vowel/h'
+        }
+        if (phonologyPositionMap[normalizedValue]) {
+          detailed.push({
+            tag: `phonology-position-${normalizedValue}`,
+            display: phonologyPositionMap[normalizedValue],
+            class: wordThemeClass,
+            description: `Phonology position: ${formatSlugLabel(normalizedValue)}`
           })
         }
       }
@@ -439,6 +690,31 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
         }
       }
     })
+
+    if (Array.isArray(optionalTags)) {
+      optionalTags.forEach((tag, index) => {
+        const attributeStableId = tag?.attribute_stable_id
+        const normalizedValue = normalizeValue(tag?.value_label)
+        if (!normalizedValue) return
+        if (!(attributeStableId === 'metaattr_optional_tag' || String(attributeStableId || '').startsWith('metaattr_opt_tag_'))) {
+          return
+        }
+
+        const optionalTagMap = {
+          'multi_word_expression': 'MWE',
+          'prepositional_phrase': 'prep phrase',
+          'temporal_expression': 'temporal expr.'
+        }
+        const display = optionalTagMap[normalizedValue] || formatSlugLabel(normalizedValue)
+
+        detailed.push({
+          tag: `optional-tag-${normalizedValue}-${index}`,
+          display,
+          class: 'bg-gray-500 text-white',
+          description: `Optional tag: ${formatSlugLabel(normalizedValue)}`
+        })
+      })
+    }
 
     return { essential, detailed }
   }
@@ -508,7 +784,8 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
 
   const colors = getWordTypeColors(word.word_type)
   const displayCoreTags = word.word_display_core_tags || word.word_core_tags || []
-  const processedTags = processRpcTagsForDisplay(displayCoreTags, word.word_type)
+  const wordOptionalTags = Array.isArray(word.word_optional_tags) ? word.word_optional_tags : []
+  const processedTags = processRpcTagsForDisplay(displayCoreTags, word.word_type, wordOptionalTags)
   const pronunciationGroups = Array.isArray(word.pronunciation_groups)
     ? word.pronunciation_groups
     : []
@@ -627,7 +904,16 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
   const renderTranslationChips = (translation, hasMultipleWordLevelTransitivities = false) => {
     const chips = []
     const core = Array.isArray(translation.rpc_core) ? translation.rpc_core : []
-    const optional = Array.isArray(translation.rpc_tags) ? translation.rpc_tags : []
+    const normalizeValue = (value) => String(value || '').trim().toLowerCase()
+    const defaultChipClass = 'tag-detailed text-xs px-2 py-0.5 rounded-full font-semibold border bg-transparent text-gray-700 border-gray-400'
+    const addTextChip = (symbol, title) => {
+      if (!symbol) return
+      chips.push({
+        symbol,
+        title,
+        className: defaultChipClass
+      })
+    }
 
     // Auxiliary Verb (metaattr002): ONLY show when multiple auxiliaries exist at word level
     if (hasMultipleWordLevelAuxiliaries) {
@@ -750,6 +1036,23 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       }
     })
 
+    // Additional register values currently present locally
+    core.forEach(tag => {
+      if (!isAttribute(tag, ATTRIBUTES.REGISTER)) return
+      const value = normalizeValue(tag.value_label)
+      const registerLabelMap = {
+        'archaic': 'archaic',
+        'informal': 'informal',
+        'literary': 'literary',
+        'regional': 'regional',
+        'vulgar': 'vulgar'
+      }
+      if (value === 'neutral') return
+      if (registerLabelMap[value]) {
+        addTextChip(registerLabelMap[value], `${registerLabelMap[value]} register`)
+      }
+    })
+
     // Transitivity chips (translation-level): ONLY show when multiple transitivity values exist at word level
     if (hasMultipleWordLevelTransitivities) {
       core.forEach(tag => {
@@ -765,6 +1068,125 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
         }
       })
     }
+
+    // Additional translation-level mapping coverage
+    core.forEach(tag => {
+      const attributeStableId = tag.attribute_stable_id
+      const value = normalizeValue(tag.value_label)
+
+      if (attributeStableId === 'metaattr031') {
+        const articlePatternMap = {
+          'definite-required': 'def. article',
+          'no-article': 'no article',
+          'flexible-article': 'flex article',
+          'definite-or-partitive': 'def/partitive',
+          'optional-article': 'opt article',
+          'fixed-no-article': 'fixed no article'
+        }
+        if (articlePatternMap[value]) {
+          addTextChip(articlePatternMap[value], `Article pattern: ${articlePatternMap[value]}`)
+        }
+      } else if (attributeStableId === 'metaattr059') {
+        const cliticAvailabilityMap = {
+          'core-clitic': 'core clitic',
+          'supports_clitics': 'supports clitics',
+          'no_clitics': 'no clitics',
+          'no-clitics': 'no clitics',
+          'reflexive-clitic': 'refl clitic',
+          'indirect-clitic': 'indirect clitic',
+          'optional-clitic': 'opt clitic',
+          'reciprocal-clitic': 'recip clitic'
+        }
+        if (cliticAvailabilityMap[value]) {
+          addTextChip(cliticAvailabilityMap[value], `Clitic availability: ${cliticAvailabilityMap[value]}`)
+        }
+      } else if (attributeStableId === 'metaattr032') {
+        const countableMap = {
+          'countable': 'countable',
+          'uncountable': 'uncountable'
+        }
+        if (countableMap[value]) {
+          addTextChip(countableMap[value], `Countability: ${countableMap[value]}`)
+        }
+      } else if (attributeStableId === 'metaattr055') {
+        const governmentMap = {
+          'governs_a': 'gov. a',
+          'governs_di': 'gov. di',
+          'governs_da': 'gov. da',
+          'governs_in': 'gov. in',
+          'governs_con': 'gov. con',
+          'governs_su': 'gov. su',
+          'governs_per': 'gov. per',
+          'invariable': 'gov. invar'
+        }
+        if (governmentMap[value]) {
+          addTextChip(governmentMap[value], `Government: ${governmentMap[value]}`)
+        }
+      } else if (attributeStableId === 'metaattr009') {
+        const gradableMap = {
+          'analytical-gradability': 'analytical',
+          'full-gradability': 'full grad.',
+          'non-gradable': 'non-grad.'
+        }
+        if (gradableMap[value]) {
+          addTextChip(gradableMap[value], `Gradability: ${gradableMap[value]}`)
+        }
+      } else if (attributeStableId === 'metaattr050') {
+        const interjectionTypeMap = {
+          'acknowledgment': 'acknowledgment',
+          'cognitive': 'cognitive',
+          'greeting': 'greeting',
+          'exclamation': 'exclamation',
+          'cultural-phrase': 'cultural phrase'
+        }
+        if (interjectionTypeMap[value]) {
+          addTextChip(interjectionTypeMap[value], `Interjection type: ${interjectionTypeMap[value]}`)
+        }
+      } else if (attributeStableId === 'metaattr063') {
+        const logicalRelationshipMap = {
+          'addition': 'addition',
+          'contrast': 'contrast',
+          'disjunction': 'disjunction',
+          'causal': 'causal',
+          'conditional': 'conditional',
+          'temporal': 'temporal',
+          'purpose': 'purpose',
+          'relative': 'relative'
+        }
+        if (logicalRelationshipMap[value]) {
+          addTextChip(logicalRelationshipMap[value], `Logical relationship: ${logicalRelationshipMap[value]}`)
+        }
+      } else if (attributeStableId === 'metaattr021') {
+        const verbTypeMap = {
+          'defective-verb': 'defective',
+          'impersonal-verb': 'impersonal',
+          'meteorological-verb': 'meteorological',
+          'modal-verb': 'modal',
+          'direct-reflexive': 'direct reflexive',
+          'reciprocal': 'reciprocal',
+          'pronominal-variant': 'pronominal',
+          'transitive-verb': 'transitive',
+          'intransitive-verb': 'intransitive'
+        }
+        if (verbTypeMap[value]) {
+          addTextChip(verbTypeMap[value], `Verb type: ${verbTypeMap[value]}`)
+        }
+      } else if (attributeStableId === 'metaattr013') {
+        const wordRestrictionMap = {
+          'invariable': 'invariable',
+          'plural-only': 'plural only',
+          'only-plural': 'plural only',
+          'singular-only': 'singular only',
+          'third-person-only': '3rd person only',
+          'third-singular-only': '3sg only',
+          'missing-first-second-person': 'no 1st/2nd',
+          'missing-imperative': 'no imperative'
+        }
+        if (wordRestrictionMap[value]) {
+          addTextChip(wordRestrictionMap[value], `Word restriction: ${wordRestrictionMap[value]}`)
+        }
+      }
+    })
 
     return chips
   }

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -1271,7 +1271,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
                   className="rounded-xl border border-white/70 bg-white/75 px-3 py-2 shadow-sm"
                 >
                   <div className="mb-2 flex items-center gap-2 flex-wrap">
-                    <span className="text-sm italic font-medium text-gray-600">
+                    <span className="text-base italic font-medium text-gray-600">
                       {groupLabel}
                     </span>
                     <AudioButton
@@ -1354,7 +1354,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             {grammarMetadataTags.map((tag, index) => (
               <span
                 key={`grammar-${index}`}
-                className={`tag-detailed text-[11px] px-2 py-0.5 rounded-full font-medium ${themeOutlineChipClass}`}
+                className={`tag-detailed text-[10px] px-1.5 py-0.5 rounded-full font-medium ${themeOutlineChipClass}`}
                 data-description={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -986,13 +986,13 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     const chips = []
     const core = Array.isArray(translation.rpc_core) ? translation.rpc_core : []
     const normalizeValue = (value) => String(value || '').trim().toLowerCase()
-    const defaultChipClass = 'tag-detailed text-xs px-2 py-0.5 rounded-full font-semibold border bg-transparent text-gray-700 border-gray-400'
+    const filledRegisterChipClass = 'inline-block text-xs px-2 py-0.5 rounded-full font-semibold border bg-slate-500 text-white border-slate-500'
     const addTextChip = (symbol, title) => {
       if (!symbol) return
       chips.push({
         symbol,
         title,
-        className: defaultChipClass
+        className: filledRegisterChipClass
       })
     }
 
@@ -1003,19 +1003,19 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
           chips.push({
             symbol: TAG_DISPLAYS[VALUES.REGISTER_FORMAL].display,
             title: 'Formal register - use in professional/elevated contexts',
-            className: TAG_DISPLAYS[VALUES.REGISTER_FORMAL].class
+            className: filledRegisterChipClass
           })
         } else if (isValue(tag, VALUES.REGISTER_CASUAL)) {
           chips.push({
             symbol: TAG_DISPLAYS[VALUES.REGISTER_CASUAL].display,
             title: 'Casual register - informal/everyday speech',
-            className: TAG_DISPLAYS[VALUES.REGISTER_CASUAL].class
+            className: filledRegisterChipClass
           })
         } else if (isValue(tag, VALUES.REGISTER_MIXED)) {
           chips.push({
             symbol: TAG_DISPLAYS[VALUES.REGISTER_MIXED].display,
             title: 'Mixed register - appropriate in both formal and casual contexts',
-            className: TAG_DISPLAYS[VALUES.REGISTER_MIXED].class
+            className: filledRegisterChipClass
           })
         }
         // Note: REGISTER_NEUTRAL is intentionally excluded (not displayed)
@@ -1322,7 +1322,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             {primaryMetadataTags.map((tag, index) => (
               <span
                 key={`primary-${index}`}
-                className={`wordcard-primary-chip inline-block text-xs px-2 py-1 rounded-full font-semibold leading-none ${tag.class}`}
+                className={`wordcard-primary-chip inline-block text-[13px] px-2.5 py-1 rounded-full font-semibold leading-none ${tag.class}`}
                 data-description={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}
@@ -1354,7 +1354,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             {grammarMetadataTags.map((tag, index) => (
               <span
                 key={`grammar-${index}`}
-                className={`wordcard-grammar-chip inline-block text-[9px] px-1.5 py-px rounded-full font-medium leading-none ${themeOutlineChipClass}`}
+                className={`wordcard-grammar-chip inline-block text-[10px] px-2 py-0.5 rounded-full font-medium leading-none ${themeOutlineChipClass}`}
                 data-description={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -846,7 +846,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     // document-level listener: event.target may be a Text node; guard for closest support
     const target = event.target
     const element = target && target.nodeType === 1 ? target : target?.parentElement
-    if (!element?.closest || !element.closest('.tag-essential, .tag-detailed, .wordcard-lexical-chip')) {
+    if (!element?.closest || !element.closest('.tag-essential, .tag-detailed, .wordcard-primary-chip, .wordcard-secondary-chip, .wordcard-grammar-chip')) {
       setTooltip((prev) => ({ ...prev, show: false }))
     }
   }
@@ -1322,7 +1322,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             {primaryMetadataTags.map((tag, index) => (
               <span
                 key={`primary-${index}`}
-                className={`tag-detailed text-xs px-2 py-1 rounded-full font-semibold ${tag.class}`}
+                className={`wordcard-primary-chip inline-block text-xs px-2 py-1 rounded-full font-semibold leading-none ${tag.class}`}
                 data-description={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}
@@ -1338,7 +1338,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             {lexicalMetadataTags.map((tag, index) => (
               <span
                 key={`lexical-${index}`}
-                className={`wordcard-lexical-chip inline-block text-[9px] px-1 py-px rounded-full font-medium leading-none ${tag.class}`}
+                className={`wordcard-secondary-chip inline-block text-[10px] px-1.5 py-0.5 rounded-full font-medium leading-none ${tag.class}`}
                 data-description={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}
@@ -1354,7 +1354,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             {grammarMetadataTags.map((tag, index) => (
               <span
                 key={`grammar-${index}`}
-                className={`tag-detailed text-[10px] px-1.5 py-0.5 rounded-full font-medium ${themeOutlineChipClass}`}
+                className={`wordcard-grammar-chip inline-block text-[9px] px-1.5 py-px rounded-full font-medium leading-none ${themeOutlineChipClass}`}
                 data-description={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -846,7 +846,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     // document-level listener: event.target may be a Text node; guard for closest support
     const target = event.target
     const element = target && target.nodeType === 1 ? target : target?.parentElement
-    if (!element?.closest || !element.closest('.tag-essential, .tag-detailed')) {
+    if (!element?.closest || !element.closest('.tag-essential, .tag-detailed, .wordcard-lexical-chip')) {
       setTooltip((prev) => ({ ...prev, show: false }))
     }
   }
@@ -1338,7 +1338,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             {lexicalMetadataTags.map((tag, index) => (
               <span
                 key={`lexical-${index}`}
-                className={`tag-detailed text-[9px] px-1 py-px rounded-full font-medium ${tag.class}`}
+                className={`wordcard-lexical-chip inline-block text-[9px] px-1 py-px rounded-full font-medium leading-none ${tag.class}`}
                 data-description={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -846,7 +846,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     // document-level listener: event.target may be a Text node; guard for closest support
     const target = event.target
     const element = target && target.nodeType === 1 ? target : target?.parentElement
-    if (!element?.closest || !element.closest('.tag-essential, .tag-detailed, .wordcard-primary-chip, .wordcard-secondary-chip, .wordcard-grammar-chip')) {
+    if (!element?.closest || !element.closest('.tag-essential, .tag-detailed, .wordcard-primary-chip, .wordcard-secondary-chip, .wordcard-grammar-chip, .wordcard-sense-chip')) {
       setTooltip((prev) => ({ ...prev, show: false }))
     }
   }
@@ -986,7 +986,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     const chips = []
     const core = Array.isArray(translation.rpc_core) ? translation.rpc_core : []
     const normalizeValue = (value) => String(value || '').trim().toLowerCase()
-    const filledRegisterChipClass = 'inline-block text-xs px-2 py-0.5 rounded-full font-semibold border bg-slate-500 text-white border-slate-500'
+    const filledRegisterChipClass = 'inline-block text-[13px] px-2.5 py-1 rounded-full font-semibold leading-none border bg-slate-500 text-white border-slate-500'
     const addTextChip = (symbol, title) => {
       if (!symbol) return
       chips.push({
@@ -1158,7 +1158,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
                   {meaningChips.map((chip, chipIndex) => (
                     <span
                       key={`meaning-chip-${groupKey}-${index}-${chipIndex}`}
-                      className={`tag-essential ${chip.className}`}
+                      className={`wordcard-sense-chip ${chip.className}`}
                       data-description={chip.title}
                       onClick={handleTagClick}
                       style={{ cursor: 'pointer' }}
@@ -1354,7 +1354,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             {grammarMetadataTags.map((tag, index) => (
               <span
                 key={`grammar-${index}`}
-                className={`wordcard-grammar-chip inline-block text-[10px] px-2 py-0.5 rounded-full font-medium leading-none ${themeOutlineChipClass}`}
+                className={`wordcard-grammar-chip inline-block text-[12px] px-2.5 py-1 rounded-full font-semibold leading-none ${themeOutlineChipClass}`}
                 data-description={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -169,7 +169,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             tag: `freq-rank-${normalizedValue}`,
             display: `⭐ ${freqMap[normalizedValue]}`,
             class: 'bg-yellow-500 text-white',
-            description: `Top ${normalizedValue.replace('top', '').replace('10000', '10,000')} most frequent words`
+            description: `Frequency rank: this lemma is in the top ${normalizedValue.replace('top', '').replace('10000', '10,000')} most frequent words in the corpus`
           })
         }
       }
@@ -186,9 +186,9 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
         if (tierMap[normalizedValue]) {
           detailed.push({
             tag: `freq-tier-${normalizedValue}`,
-            display: tierMap[normalizedValue],
+            display: `freq ${tierMap[normalizedValue]}`,
             class: 'bg-yellow-500 text-white',
-            description: `Frequency tier: ${tierMap[normalizedValue]}`
+            description: `Frequency tier: pedagogical band derived from corpus rank (${tierMap[normalizedValue]})`
           })
         }
       }
@@ -482,168 +482,269 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       }
       else if (attributeStableId === 'metaattr030') {
         const adjectiveTypeMap = {
-          'qualitative': 'qualitative',
-          'fixed-comparative': 'fixed comp.',
-          'relational': 'relational'
+          'qualitative': {
+            display: 'qualitative',
+            description: 'Adjective type: expresses an inherent quality and is usually gradable'
+          },
+          'fixed-comparative': {
+            display: 'fixed comp.',
+            description: 'Adjective type: lexicalized comparative/superlative form, not regular gradation'
+          },
+          'relational': {
+            display: 'relational',
+            description: 'Adjective type: category/material/origin adjective, usually not gradable'
+          }
         }
         if (adjectiveTypeMap[normalizedValue]) {
           detailed.push({
             tag: `adjective-type-${normalizedValue}`,
-            display: adjectiveTypeMap[normalizedValue],
+            display: adjectiveTypeMap[normalizedValue].display,
             class: wordThemeClass,
-            description: `Adjective type: ${adjectiveTypeMap[normalizedValue]}`
+            description: adjectiveTypeMap[normalizedValue].description
           })
         }
       }
       else if (attributeStableId === 'metaattr_matrix5_abbreviation_type') {
         const abbreviationTypeMap = {
-          'initialism': 'initialism',
-          'acronym': 'acronym'
+          'initialism': {
+            display: 'initialism',
+            description: 'Abbreviation type: pronounced letter by letter (e.g. U.S.A.)'
+          },
+          'acronym': {
+            display: 'acronym',
+            description: 'Abbreviation type: pronounced like a word (e.g. NATO)'
+          }
         }
         if (abbreviationTypeMap[normalizedValue]) {
           detailed.push({
             tag: `abbreviation-type-${normalizedValue}`,
-            display: abbreviationTypeMap[normalizedValue],
+            display: abbreviationTypeMap[normalizedValue].display,
             class: wordThemeClass,
-            description: `Abbreviation type: ${abbreviationTypeMap[normalizedValue]}`
+            description: abbreviationTypeMap[normalizedValue].description
           })
         }
       }
       else if (attributeStableId === 'metaattr_matrix5_affix_type') {
         const affixTypeMap = {
-          'prefix': 'prefix'
+          'prefix': {
+            display: 'prefix',
+            description: 'Affix type: morpheme attached before a base word'
+          }
         }
         if (affixTypeMap[normalizedValue]) {
           detailed.push({
             tag: `affix-type-${normalizedValue}`,
-            display: affixTypeMap[normalizedValue],
+            display: affixTypeMap[normalizedValue].display,
             class: wordThemeClass,
-            description: `Affix type: ${affixTypeMap[normalizedValue]}`
+            description: affixTypeMap[normalizedValue].description
           })
         }
       }
       else if (attributeStableId === 'metaattr062') {
         const conjunctionTypeMap = {
-          'coordinating': 'coord.',
-          'subordinating': 'subord.',
-          'correlative': 'correl.'
+          'coordinating': {
+            display: 'coord.',
+            description: 'Conjunction type: links words/clauses of equal grammatical rank'
+          },
+          'subordinating': {
+            display: 'subord.',
+            description: 'Conjunction type: introduces a subordinate clause'
+          },
+          'correlative': {
+            display: 'correl.',
+            description: 'Conjunction type: paired construction (e.g. either...or)'
+          }
         }
         if (conjunctionTypeMap[normalizedValue]) {
           detailed.push({
             tag: `conjunction-type-${normalizedValue}`,
-            display: conjunctionTypeMap[normalizedValue],
+            display: conjunctionTypeMap[normalizedValue].display,
             class: wordThemeClass,
-            description: `Conjunction type: ${formatSlugLabel(normalizedValue)}`
+            description: conjunctionTypeMap[normalizedValue].description
           })
         }
       }
       else if (attributeStableId === 'metaattr061') {
         const determinerTypeMap = {
-          'article': 'article',
-          'demonstrative': 'demonstrative',
-          'indefinite-article': 'indef. article',
-          'interrogative': 'interrogative',
-          'possessive': 'possessive',
-          'quantifier': 'quantifier'
+          'article': {
+            display: 'det article',
+            description: 'Determiner type: article determiner'
+          },
+          'demonstrative': {
+            display: 'det demonstr.',
+            description: 'Determiner type: points to a specific referent (this/that)'
+          },
+          'indefinite-article': {
+            display: 'det indef.',
+            description: 'Determiner type: introduces a non-specific referent'
+          },
+          'interrogative': {
+            display: 'det interrog.',
+            description: 'Determiner type: used to ask which/what/how many'
+          },
+          'possessive': {
+            display: 'det possess.',
+            description: 'Determiner type: marks possession/association'
+          },
+          'quantifier': {
+            display: 'det quant.',
+            description: 'Determiner type: expresses quantity or amount'
+          }
         }
         if (determinerTypeMap[normalizedValue]) {
           detailed.push({
             tag: `determiner-type-${normalizedValue}`,
-            display: determinerTypeMap[normalizedValue],
+            display: determinerTypeMap[normalizedValue].display,
             class: wordThemeClass,
-            description: `Determiner type: ${determinerTypeMap[normalizedValue]}`
+            description: determinerTypeMap[normalizedValue].description
           })
         }
       }
       else if (attributeStableId === 'metaattr069') {
         const expressionTypeMap = {
-          'single-word': 'single word',
-          'multiword-expression': 'multiword'
+          'single-word': {
+            display: 'single word',
+            description: 'Expression type: one lexical word'
+          },
+          'multiword-expression': {
+            display: 'multiword',
+            description: 'Expression type: fixed or conventional multiword expression'
+          }
         }
         if (expressionTypeMap[normalizedValue]) {
           detailed.push({
             tag: `expression-type-${normalizedValue}`,
-            display: expressionTypeMap[normalizedValue],
+            display: expressionTypeMap[normalizedValue].display,
             class: wordThemeClass,
-            description: `Expression type: ${expressionTypeMap[normalizedValue]}`
+            description: expressionTypeMap[normalizedValue].description
           })
         }
       }
       else if (attributeStableId === 'metaattr060') {
         const prepositionTypeMap = {
-          'simple': 'simple prep.',
-          'complex': 'complex prep.',
-          'contracted': 'contracted prep.'
+          'simple': {
+            display: 'simple prep.',
+            description: 'Preposition type: single-word basic preposition'
+          },
+          'complex': {
+            display: 'complex prep.',
+            description: 'Preposition type: multiword prepositional expression'
+          },
+          'contracted': {
+            display: 'contracted prep.',
+            description: 'Preposition type: fused preposition+article form'
+          }
         }
         if (prepositionTypeMap[normalizedValue]) {
           detailed.push({
             tag: `preposition-type-${normalizedValue}`,
-            display: prepositionTypeMap[normalizedValue],
+            display: prepositionTypeMap[normalizedValue].display,
             class: wordThemeClass,
-            description: `Preposition type: ${formatSlugLabel(normalizedValue)}`
+            description: prepositionTypeMap[normalizedValue].description
           })
         }
       }
       else if (attributeStableId === 'metaattr041') {
         const pronounFormMap = {
-          'full': 'full pron.',
-          'clitic': 'clitic pron.',
-          'combined': 'combined pron.',
-          'elision': 'elided pron.'
+          'full': {
+            display: 'form full',
+            description: 'Pronoun form: full standalone pronoun form'
+          },
+          'clitic': {
+            display: 'form clitic',
+            description: 'Pronoun form: clitic form that attaches to a verb'
+          },
+          'combined': {
+            display: 'form combined',
+            description: 'Pronoun form: combined clitic cluster'
+          },
+          'elision': {
+            display: 'form elision',
+            description: 'Pronoun form: elided form with apostrophe'
+          }
         }
         if (pronounFormMap[normalizedValue]) {
           detailed.push({
             tag: `pronoun-form-${normalizedValue}`,
-            display: pronounFormMap[normalizedValue],
+            display: pronounFormMap[normalizedValue].display,
             class: wordThemeClass,
-            description: `Pronoun form: ${formatSlugLabel(normalizedValue)}`
+            description: pronounFormMap[normalizedValue].description
           })
         }
       }
       else if (attributeStableId === 'metaattr040') {
         const pronounTypeMap = {
-          'personal': 'personal pron.',
-          'clitic': 'clitic pron.',
-          'indefinite': 'indef. pron.',
-          'relative': 'relative pron.',
-          'demonstrative': 'demonstrative pron.'
+          'personal': {
+            display: 'pron personal',
+            description: 'Pronoun type: personal pronoun'
+          },
+          'clitic': {
+            display: 'pron clitic',
+            description: 'Pronoun type: clitic-pronoun category'
+          },
+          'indefinite': {
+            display: 'pron indef.',
+            description: 'Pronoun type: indefinite pronoun'
+          },
+          'relative': {
+            display: 'pron relative',
+            description: 'Pronoun type: relative pronoun introducing a relative clause'
+          },
+          'demonstrative': {
+            display: 'pron demonstr.',
+            description: 'Pronoun type: demonstrative pronoun'
+          }
         }
         if (pronounTypeMap[normalizedValue]) {
           detailed.push({
             tag: `pronoun-type-${normalizedValue}`,
-            display: pronounTypeMap[normalizedValue],
+            display: pronounTypeMap[normalizedValue].display,
             class: wordThemeClass,
-            description: `Pronoun type: ${formatSlugLabel(normalizedValue)}`
+            description: pronounTypeMap[normalizedValue].description
           })
         }
       }
       else if (attributeStableId === 'metaattr035') {
         const phonologyPositionMap = {
-          'after-noun': 'post-nom.',
-          'before-most-consonants': 'pre consonant',
-          'before-impure-consonant': 'pre impure',
-          'before-vowel-or-h': 'pre vowel/h'
+          'after-noun': {
+            display: 'post-nom.',
+            description: 'Phonology position: form used after the noun'
+          },
+          'before-most-consonants': {
+            display: 'pre consonant',
+            description: 'Phonology position: form used before most consonant onsets'
+          },
+          'before-impure-consonant': {
+            display: 'pre impure',
+            description: 'Phonology position: form used before impure consonants (s+consonant, z, gn, ps, x)'
+          },
+          'before-vowel-or-h': {
+            display: 'pre vowel/h',
+            description: 'Phonology position: form used before vowel or silent h'
+          }
         }
         if (phonologyPositionMap[normalizedValue]) {
           detailed.push({
             tag: `phonology-position-${normalizedValue}`,
-            display: phonologyPositionMap[normalizedValue],
+            display: phonologyPositionMap[normalizedValue].display,
             class: wordThemeClass,
-            description: `Phonology position: ${formatSlugLabel(normalizedValue)}`
+            description: phonologyPositionMap[normalizedValue].description
           })
         }
       }
       else if (attributeStableId === 'metaattr057' && wordType === 'NOUN') {
         const nounTypeMap = {
-          common: 'common',
-          proper: 'proper'
+          common: 'common noun',
+          proper: 'proper noun'
         }
         if (nounTypeMap[valueLabel]) {
           detailed.push({
             tag: `noun-type-${valueLabel}`,
             display: nounTypeMap[valueLabel],
             class: 'bg-cyan-500 text-white',
-            description: `Noun type: ${nounTypeMap[valueLabel]}`
+            description: valueLabel === 'common'
+              ? 'Noun type: common noun (not a unique name)'
+              : 'Noun type: proper noun (name of a specific person/place/entity)'
           })
         }
       }
@@ -880,11 +981,18 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
 
     const cefrLevelTags = bottomTags.filter((tag) => typeof tag?.tag === 'string' && tag.tag.startsWith('CEFR-'))
     const cefrTierTags = bottomTags.filter((tag) => typeof tag?.tag === 'string' && tag.tag.startsWith('cefr-tier-'))
+    const frequencyRankTags = bottomTags.filter((tag) => typeof tag?.tag === 'string' && tag.tag.startsWith('freq-rank-'))
+    const frequencyTierTags = bottomTags.filter((tag) => typeof tag?.tag === 'string' && tag.tag.startsWith('freq-tier-'))
     const otherTags = bottomTags.filter((tag) =>
-      !(typeof tag?.tag === 'string' && (tag.tag.startsWith('CEFR-') || tag.tag.startsWith('cefr-tier-')))
+      !(typeof tag?.tag === 'string' && (
+        tag.tag.startsWith('CEFR-') ||
+        tag.tag.startsWith('cefr-tier-') ||
+        tag.tag.startsWith('freq-rank-') ||
+        tag.tag.startsWith('freq-tier-')
+      ))
     )
 
-    return [...cefrLevelTags, ...cefrTierTags, ...otherTags]
+    return [...cefrLevelTags, ...cefrTierTags, ...frequencyRankTags, ...frequencyTierTags, ...otherTags]
   })()
 
   // Get translations - use processedTranslations from EnhancedDictionarySystem
@@ -1076,114 +1184,285 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
 
       if (attributeStableId === 'metaattr031') {
         const articlePatternMap = {
-          'definite-required': 'def. article',
-          'no-article': 'no article',
-          'flexible-article': 'flex article',
-          'definite-or-partitive': 'def/partitive',
-          'optional-article': 'opt article',
-          'fixed-no-article': 'fixed no article'
+          'definite-required': {
+            display: 'def. article',
+            description: 'Article pattern: this sense is normally used with a definite article'
+          },
+          'no-article': {
+            display: 'no article',
+            description: 'Article pattern: this sense is normally used without an article'
+          },
+          'flexible-article': {
+            display: 'flex article',
+            description: 'Article pattern: article choice varies by context'
+          },
+          'definite-or-partitive': {
+            display: 'def/partitive',
+            description: 'Article pattern: typically definite or partitive depending on meaning'
+          },
+          'optional-article': {
+            display: 'opt article',
+            description: 'Article pattern: article may be omitted in some standard contexts'
+          },
+          'fixed-no-article': {
+            display: 'fixed no article',
+            description: 'Article pattern: lexicalized fixed construction without article'
+          }
         }
         if (articlePatternMap[value]) {
-          addTextChip(articlePatternMap[value], `Article pattern: ${articlePatternMap[value]}`)
+          addTextChip(articlePatternMap[value].display, articlePatternMap[value].description)
         }
       } else if (attributeStableId === 'metaattr059') {
         const cliticAvailabilityMap = {
-          'core-clitic': 'core clitic',
-          'supports_clitics': 'supports clitics',
-          'no_clitics': 'no clitics',
-          'no-clitics': 'no clitics',
-          'reflexive-clitic': 'refl clitic',
-          'indirect-clitic': 'indirect clitic',
-          'optional-clitic': 'opt clitic',
-          'reciprocal-clitic': 'recip clitic'
+          'core-clitic': {
+            display: 'core clitic',
+            description: 'Clitic availability: clitic usage is core/expected for this entry'
+          },
+          'supports_clitics': {
+            display: 'supports clitics',
+            description: 'Clitic availability: clitic usage is supported'
+          },
+          'no_clitics': {
+            display: 'no clitics',
+            description: 'Clitic availability: clitic forms are not used'
+          },
+          'no-clitics': {
+            display: 'no clitics',
+            description: 'Clitic availability: clitic forms are not used'
+          },
+          'reflexive-clitic': {
+            display: 'refl clitic',
+            description: 'Clitic availability: reflexive clitic usage'
+          },
+          'indirect-clitic': {
+            display: 'indirect clitic',
+            description: 'Clitic availability: indirect-object clitic usage'
+          },
+          'optional-clitic': {
+            display: 'opt clitic',
+            description: 'Clitic availability: clitic usage is optional'
+          },
+          'reciprocal-clitic': {
+            display: 'recip clitic',
+            description: 'Clitic availability: reciprocal clitic usage'
+          }
         }
         if (cliticAvailabilityMap[value]) {
-          addTextChip(cliticAvailabilityMap[value], `Clitic availability: ${cliticAvailabilityMap[value]}`)
+          addTextChip(cliticAvailabilityMap[value].display, cliticAvailabilityMap[value].description)
         }
       } else if (attributeStableId === 'metaattr032') {
         const countableMap = {
-          'countable': 'countable',
-          'uncountable': 'uncountable'
+          'countable': {
+            display: 'countable',
+            description: 'Countability: can normally be counted and pluralized'
+          },
+          'uncountable': {
+            display: 'uncountable',
+            description: 'Countability: mass/uncountable usage in this sense'
+          }
         }
         if (countableMap[value]) {
-          addTextChip(countableMap[value], `Countability: ${countableMap[value]}`)
+          addTextChip(countableMap[value].display, countableMap[value].description)
         }
       } else if (attributeStableId === 'metaattr055') {
         const governmentMap = {
-          'governs_a': 'gov. a',
-          'governs_di': 'gov. di',
-          'governs_da': 'gov. da',
-          'governs_in': 'gov. in',
-          'governs_con': 'gov. con',
-          'governs_su': 'gov. su',
-          'governs_per': 'gov. per',
-          'invariable': 'gov. invar'
+          'governs_a': {
+            display: 'gov. a',
+            description: 'Government: this sense typically governs preposition "a"'
+          },
+          'governs_di': {
+            display: 'gov. di',
+            description: 'Government: this sense typically governs preposition "di"'
+          },
+          'governs_da': {
+            display: 'gov. da',
+            description: 'Government: this sense typically governs preposition "da"'
+          },
+          'governs_in': {
+            display: 'gov. in',
+            description: 'Government: this sense typically governs preposition "in"'
+          },
+          'governs_con': {
+            display: 'gov. con',
+            description: 'Government: this sense typically governs preposition "con"'
+          },
+          'governs_su': {
+            display: 'gov. su',
+            description: 'Government: this sense typically governs preposition "su"'
+          },
+          'governs_per': {
+            display: 'gov. per',
+            description: 'Government: this sense typically governs preposition "per"'
+          },
+          'invariable': {
+            display: 'gov. invar',
+            description: 'Government: no single fixed governing preposition'
+          }
         }
         if (governmentMap[value]) {
-          addTextChip(governmentMap[value], `Government: ${governmentMap[value]}`)
+          addTextChip(governmentMap[value].display, governmentMap[value].description)
         }
       } else if (attributeStableId === 'metaattr009') {
         const gradableMap = {
-          'analytical-gradability': 'analytical',
-          'full-gradability': 'full grad.',
-          'non-gradable': 'non-grad.'
+          'analytical-gradability': {
+            display: 'analytical',
+            description: 'Gradability: comparative/superlative usually formed analytically (più/meno)'
+          },
+          'full-gradability': {
+            display: 'full grad.',
+            description: 'Gradability: supports full gradation behavior'
+          },
+          'non-gradable': {
+            display: 'non-grad.',
+            description: 'Gradability: not normally gradable in this sense'
+          }
         }
         if (gradableMap[value]) {
-          addTextChip(gradableMap[value], `Gradability: ${gradableMap[value]}`)
+          addTextChip(gradableMap[value].display, gradableMap[value].description)
         }
       } else if (attributeStableId === 'metaattr050') {
         const interjectionTypeMap = {
-          'acknowledgment': 'acknowledgment',
-          'cognitive': 'cognitive',
-          'greeting': 'greeting',
-          'exclamation': 'exclamation',
-          'cultural-phrase': 'cultural phrase'
+          'acknowledgment': {
+            display: 'acknowledgment',
+            description: 'Interjection type: acknowledgment response'
+          },
+          'cognitive': {
+            display: 'cognitive',
+            description: 'Interjection type: expresses thought/realization'
+          },
+          'greeting': {
+            display: 'greeting',
+            description: 'Interjection type: greeting/farewell expression'
+          },
+          'exclamation': {
+            display: 'exclamation',
+            description: 'Interjection type: exclamatory reaction'
+          },
+          'cultural-phrase': {
+            display: 'cultural phrase',
+            description: 'Interjection type: fixed cultural expression'
+          }
         }
         if (interjectionTypeMap[value]) {
-          addTextChip(interjectionTypeMap[value], `Interjection type: ${interjectionTypeMap[value]}`)
+          addTextChip(interjectionTypeMap[value].display, interjectionTypeMap[value].description)
         }
       } else if (attributeStableId === 'metaattr063') {
         const logicalRelationshipMap = {
-          'addition': 'addition',
-          'contrast': 'contrast',
-          'disjunction': 'disjunction',
-          'causal': 'causal',
-          'conditional': 'conditional',
-          'temporal': 'temporal',
-          'purpose': 'purpose',
-          'relative': 'relative'
+          'addition': {
+            display: 'logic addition',
+            description: 'Logical relationship: adds information'
+          },
+          'contrast': {
+            display: 'logic contrast',
+            description: 'Logical relationship: marks contrast/concession'
+          },
+          'disjunction': {
+            display: 'logic disjunction',
+            description: 'Logical relationship: presents alternatives'
+          },
+          'causal': {
+            display: 'logic causal',
+            description: 'Logical relationship: gives a reason/cause'
+          },
+          'conditional': {
+            display: 'logic conditional',
+            description: 'Logical relationship: sets a condition'
+          },
+          'temporal': {
+            display: 'logic temporal',
+            description: 'Logical relationship: links events in time'
+          },
+          'purpose': {
+            display: 'logic purpose',
+            description: 'Logical relationship: indicates purpose'
+          },
+          'relative': {
+            display: 'logic relative',
+            description: 'Logical relationship: relative-linking function'
+          }
         }
         if (logicalRelationshipMap[value]) {
-          addTextChip(logicalRelationshipMap[value], `Logical relationship: ${logicalRelationshipMap[value]}`)
+          addTextChip(logicalRelationshipMap[value].display, logicalRelationshipMap[value].description)
         }
       } else if (attributeStableId === 'metaattr021') {
         const verbTypeMap = {
-          'defective-verb': 'defective',
-          'impersonal-verb': 'impersonal',
-          'meteorological-verb': 'meteorological',
-          'modal-verb': 'modal',
-          'direct-reflexive': 'direct reflexive',
-          'reciprocal': 'reciprocal',
-          'pronominal-variant': 'pronominal',
-          'transitive-verb': 'transitive',
-          'intransitive-verb': 'intransitive'
+          'defective-verb': {
+            display: 'verb defective',
+            description: 'Verb type: paradigm has missing standard forms'
+          },
+          'impersonal-verb': {
+            display: 'verb impersonal',
+            description: 'Verb type: used mainly in impersonal constructions'
+          },
+          'meteorological-verb': {
+            display: 'verb meteorol.',
+            description: 'Verb type: weather/meteorological usage'
+          },
+          'modal-verb': {
+            display: 'verb modal',
+            description: 'Verb type: modal verb used with infinitive complements'
+          },
+          'direct-reflexive': {
+            display: 'verb dir-refl',
+            description: 'Verb type: direct reflexive meaning is central'
+          },
+          'reciprocal': {
+            display: 'verb reciprocal',
+            description: 'Verb type: reciprocal (mutual action) sense'
+          },
+          'pronominal-variant': {
+            display: 'verb pronominal',
+            description: 'Verb type: pronominal variant with fixed particles/clitics'
+          },
+          'transitive-verb': {
+            display: 'verb transitive',
+            description: 'Verb type: transitive verb class'
+          },
+          'intransitive-verb': {
+            display: 'verb intransitive',
+            description: 'Verb type: intransitive verb class'
+          }
         }
         if (verbTypeMap[value]) {
-          addTextChip(verbTypeMap[value], `Verb type: ${verbTypeMap[value]}`)
+          addTextChip(verbTypeMap[value].display, verbTypeMap[value].description)
         }
       } else if (attributeStableId === 'metaattr013') {
         const wordRestrictionMap = {
-          'invariable': 'invariable',
-          'plural-only': 'plural only',
-          'only-plural': 'plural only',
-          'singular-only': 'singular only',
-          'third-person-only': '3rd person only',
-          'third-singular-only': '3sg only',
-          'missing-first-second-person': 'no 1st/2nd',
-          'missing-imperative': 'no imperative'
+          'invariable': {
+            display: 'restriction invar',
+            description: 'Word restriction: invariable usage in this sense/context'
+          },
+          'plural-only': {
+            display: 'restriction plural',
+            description: 'Word restriction: used only in plural'
+          },
+          'only-plural': {
+            display: 'restriction plural',
+            description: 'Word restriction: used only in plural'
+          },
+          'singular-only': {
+            display: 'restriction singular',
+            description: 'Word restriction: used only in singular'
+          },
+          'third-person-only': {
+            display: 'restriction 3rd',
+            description: 'Word restriction: only third-person forms are used'
+          },
+          'third-singular-only': {
+            display: 'restriction 3sg',
+            description: 'Word restriction: only third-person singular is used'
+          },
+          'missing-first-second-person': {
+            display: 'restriction no 1st/2nd',
+            description: 'Word restriction: first/second person forms are not used'
+          },
+          'missing-imperative': {
+            display: 'restriction no imp.',
+            description: 'Word restriction: imperative forms are not used'
+          }
         }
         if (wordRestrictionMap[value]) {
-          addTextChip(wordRestrictionMap[value], `Word restriction: ${wordRestrictionMap[value]}`)
+          addTextChip(wordRestrictionMap[value].display, wordRestrictionMap[value].description)
         }
       }
     })

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -601,24 +601,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
         }
       }
       else if (attributeStableId === 'metaattr069') {
-        const expressionTypeMap = {
-          'single-word': {
-            display: 'single word',
-            description: 'Expression type: one lexical word'
-          },
-          'multiword-expression': {
-            display: 'multiword',
-            description: 'Expression type: fixed or conventional multiword expression'
-          }
-        }
-        if (expressionTypeMap[normalizedValue]) {
-          detailed.push({
-            tag: `expression-type-${normalizedValue}`,
-            display: expressionTypeMap[normalizedValue].display,
-            class: wordThemeClass,
-            description: expressionTypeMap[normalizedValue].description
-          })
-        }
+        // expression_type is intentionally hidden on the word card
       }
       else if (attributeStableId === 'metaattr060') {
         const prepositionTypeMap = {
@@ -912,44 +895,6 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     return map[cls] || cls
   }
 
-  // Function to extract form-level tense chips from forms_json
-  const renderFormTenseChips = () => {
-    if (!word.forms_json || !Array.isArray(word.forms_json)) return []
-    
-    const tenseChips = []
-    const seenTenses = new Set()
-    
-    // Collect unique tenses from all forms
-    word.forms_json.forEach(form => {
-      if (form.core_tags && Array.isArray(form.core_tags)) {
-        form.core_tags.forEach(tag => {
-          if (isAttribute(tag, ATTRIBUTES.TENSE)) {
-            const valueId = tag.value_id
-            const valueLabel = tag.value_label
-            
-            // Skip if we've already seen this tense
-            if (!seenTenses.has(valueId)) {
-              seenTenses.add(valueId)
-              
-              // Map to display configuration from TAG_DISPLAYS
-              const displayConfig = TAG_DISPLAYS[valueId]
-              if (displayConfig) {
-                tenseChips.push({
-                  tag: `tense-${valueLabel}`,
-                  display: displayConfig.display,
-                  class: displayConfig.class,
-                  description: `Tense: ${valueLabel} (${form.form_text} example)`
-                })
-              }
-            }
-          }
-        })
-      }
-    })
-    
-    return tenseChips
-  }
-
   // Extract gender and irregularity tags for header
   const genderTag = processedTags.essential.find(tag =>
     tag.display === '♂' || tag.display === '♀' || tag.display === '⚥'
@@ -960,20 +905,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     ...processedTags.essential.filter(tag =>
       tag.display !== '♂' && tag.display !== '♀' && tag.display !== '⚥'
     ),
-    ...processedTags.detailed.filter(tag =>
-      ![
-        'are-conjugation',
-        'ere-conjugation',
-        'ire-conjugation',
-        'ire-isc-conjugation',
-        'ire-isc',
-        'are',
-        'ere',
-        'ire'
-      ].includes(tag.tag)
-    ),
-    // Add form-level tense chips for verbs
-    ...(word.word_type === 'VERB' ? renderFormTenseChips() : [])
+    ...processedTags.detailed
   ]
 
   const orderedBottomTags = (() => {
@@ -995,21 +927,62 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     return [...cefrLevelTags, ...cefrTierTags, ...frequencyRankTags, ...frequencyTierTags, ...otherTags]
   })()
 
-  // Get translations - use processedTranslations from EnhancedDictionarySystem
-  // Ensure translations are sorted by display_priority so the first item is truly the primary meaning
+  const primaryMetadataTags = orderedBottomTags.filter((tag) =>
+    typeof tag?.tag === 'string' && (
+      tag.tag.startsWith('CEFR-') ||
+      tag.tag.startsWith('cefr-tier-') ||
+      tag.tag.startsWith('freq-rank-') ||
+      tag.tag.startsWith('freq-tier-')
+    )
+  )
 
-  // Count unique auxiliaries at word level to determine if translation-level auxiliary chips should be shown
-  const wordLevelAuxiliaries = new Set()
-  const wordCoreTags = displayCoreTags
-  wordCoreTags.forEach(tag => {
-    if (tag.attribute_stable_id === 'metaattr002') {
-      wordLevelAuxiliaries.add(String(tag.value_label || '').toLowerCase())
-    }
-  })
-  const hasMultipleWordLevelAuxiliaries = wordLevelAuxiliaries.size > 1
+  const lexicalMetadataTags = orderedBottomTags.filter((tag) =>
+    typeof tag?.tag === 'string' && (
+      tag.tag.startsWith('abbreviation-type-') ||
+      tag.tag.startsWith('affix-type-') ||
+      tag.tag.startsWith('adjective-type-') ||
+      tag.tag.startsWith('adverb-') ||
+      tag.tag.startsWith('optional-tag-')
+    )
+  )
+
+  const grammarMetadataTags = orderedBottomTags.filter((tag) =>
+    typeof tag?.tag === 'string' && (
+      tag.tag === 'singolare' ||
+      tag.tag === 'plurale' ||
+      tag.tag === 'number-restriction-singular-only' ||
+      tag.tag === 'number-restriction-plural-only' ||
+      tag.tag === 'form-2' ||
+      tag.tag === 'form-4' ||
+      tag.tag === 'form-invariable' ||
+      tag.tag === 'reflexive' ||
+      tag.tag === 'reflexive-verb' ||
+      tag.tag === 'are-conjugation' ||
+      tag.tag === 'ere-conjugation' ||
+      tag.tag === 'ire-conjugation' ||
+      tag.tag === 'ire-isc-conjugation' ||
+      tag.tag.startsWith('plural-formation-') ||
+      tag.tag.startsWith('noun-type-') ||
+      tag.tag.startsWith('determiner-type-') ||
+      tag.tag.startsWith('preposition-type-') ||
+      tag.tag.startsWith('pronoun-form-') ||
+      tag.tag.startsWith('pronoun-type-') ||
+      tag.tag.startsWith('conjunction-type-') ||
+      tag.tag.startsWith('phonology-position-')
+    )
+  )
+
+  const themeOutlineChipClass =
+    word.word_type === 'VERB'
+      ? 'border border-teal-500 text-teal-700 bg-transparent'
+      : word.word_type === 'ADJECTIVE'
+        ? 'border border-blue-500 text-blue-700 bg-transparent'
+        : word.word_type === 'ADVERB'
+          ? 'border border-purple-500 text-purple-700 bg-transparent'
+          : 'border border-cyan-500 text-cyan-700 bg-transparent'
 
   // Translation-level chips: auxiliary, reciprocal, number restrictions, and gender restrictions
-  const renderTranslationChips = (translation, hasMultipleWordLevelTransitivities = false) => {
+  const renderTranslationChips = (translation) => {
     const chips = []
     const core = Array.isArray(translation.rpc_core) ? translation.rpc_core : []
     const normalizeValue = (value) => String(value || '').trim().toLowerCase()
@@ -1022,101 +995,6 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
         className: defaultChipClass
       })
     }
-
-    // Auxiliary Verb (metaattr002): ONLY show when multiple auxiliaries exist at word level
-    if (hasMultipleWordLevelAuxiliaries) {
-      const auxTags = core.filter((t) => t.attribute_stable_id === 'metaattr002')
-      if (auxTags.length > 0) {
-        // Each translation has only one auxiliary - show individual chip
-        const aux = auxTags[0]
-        const v = String(aux.value_label || '').toLowerCase()
-        const label = v === 'essere' ? 'ess.' : v === 'avere' ? 'av.' : (aux.value_shorthand || aux.value_label || '')
-        if (label) chips.push({ 
-          symbol: label, 
-          title: `Auxiliary: ${aux.value_label || label}`, 
-          className: 'tag-detailed text-xs px-2 py-0.5 rounded-full font-semibold border bg-transparent text-gray-700 border-gray-400' 
-        })
-      }
-    }
-
-    // Reflexive Type (metaattr021): direct-reflexive/reciprocal
-    const reflexiveTypeTags = core.filter((t) => isAttribute(t, ATTRIBUTES.REFLEXIVE_TYPE))
-    reflexiveTypeTags.forEach(tag => {
-      if (isValue(tag, VALUES.REFLEXIVE_TYPE_DIRECT)) {
-        chips.push({ 
-          symbol: '🔄', 
-          title: TAG_DISPLAYS[VALUES.REFLEXIVE_TYPE_DIRECT].description, 
-          className: 'tag-detailed text-xs px-2 py-0.5 rounded-full font-semibold border bg-transparent text-gray-700 border-gray-400' 
-        })
-      } else if (isValue(tag, VALUES.REFLEXIVE_TYPE_RECIPROCAL)) {
-        chips.push({ 
-          symbol: '🫂', 
-          title: TAG_DISPLAYS[VALUES.REFLEXIVE_TYPE_RECIPROCAL].description, 
-          className: 'tag-detailed text-xs px-2 py-0.5 rounded-full font-semibold border bg-transparent text-gray-700 border-gray-400' 
-        })
-      }
-    })
-
-    // Number Restriction: detect from core tags for translation-level restrictions (e.g., reciprocal verbs)
-    const numberRestrictionTags = core.filter((t) => isAttribute(t, ATTRIBUTES.NUMBER_RESTRICTION))
-    numberRestrictionTags.forEach(tag => {
-      if (isValue(tag, VALUES.NUMBER_RESTRICTION_SOLO_SINGOLARE)) {
-        chips.push({ 
-          symbol: '👤', 
-          title: TAG_DISPLAYS[VALUES.NUMBER_RESTRICTION_SOLO_SINGOLARE].description, 
-          className: 'tag-detailed text-xs px-2 py-0.5 rounded-full font-semibold border bg-transparent text-gray-700 border-gray-400' 
-        })
-      } else if (isValue(tag, VALUES.NUMBER_RESTRICTION_SOLO_PLURALE)) {
-        chips.push({ 
-          symbol: '👥', 
-          title: TAG_DISPLAYS[VALUES.NUMBER_RESTRICTION_SOLO_PLURALE].description, 
-          className: 'tag-detailed text-xs px-2 py-0.5 rounded-full font-semibold border bg-transparent text-gray-700 border-gray-400' 
-        })
-      }
-    })
-
-    // Gender Usage Restrictions: consolidated logic from restriction-utils.js
-    core.forEach(tag => {
-      // Check for gender usage restrictions using UUID-based attribute/value matching
-      if (hasAttributeValue(tag, ATTRIBUTES.GENDER_USAGE, VALUES.GENDER_MALE_ONLY)) {
-        chips.push({ 
-          symbol: '♂', 
-          title: 'Use only with masculine subjects', 
-          className: 'tag-detailed text-xs px-2 py-0.5 rounded-full font-semibold border bg-transparent border-blue-500 text-blue-600' 
-        })
-      } else if (hasAttributeValue(tag, ATTRIBUTES.GENDER_USAGE, VALUES.GENDER_FEMALE_ONLY)) {
-        chips.push({ 
-          symbol: '♀', 
-          title: 'Use only with feminine subjects', 
-          className: 'tag-detailed text-xs px-2 py-0.5 rounded-full font-semibold border bg-transparent border-pink-500 text-pink-600' 
-        })
-      }
-    })
-
-    // Position chips
-    core.forEach(tag => {
-      if (isAttribute(tag, ATTRIBUTES.POSITION)) {
-        if (isValue(tag, VALUES.POSITION_BEFORE)) {
-          chips.push({
-            symbol: '⬅️',
-            title: 'Positioned before another word',
-            className: 'tag-detailed text-xs px-1 py-0.5 rounded border border-gray-300 text-gray-600 bg-transparent'
-          })
-        } else if (isValue(tag, VALUES.POSITION_AFTER)) {
-          chips.push({
-            symbol: '➡️',
-            title: 'Positioned after another word',
-            className: 'tag-detailed text-xs px-1 py-0.5 rounded border border-gray-300 text-gray-600 bg-transparent'
-          })
-        } else if (isValue(tag, VALUES.POSITION_BEFORE_AFTER)) {
-          chips.push({
-            symbol: '↔️',
-            title: 'Can be positioned before or after another word',
-            className: 'tag-detailed text-xs px-1 py-0.5 rounded border border-gray-300 text-gray-600 bg-transparent'
-          })
-        }
-      }
-    })
 
     // Register chips (translation-level, emoji-only display)
     core.forEach(tag => {
@@ -1157,313 +1035,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       }
       if (value === 'neutral') return
       if (registerLabelMap[value]) {
-        addTextChip(registerLabelMap[value], `${registerLabelMap[value]} register`)
-      }
-    })
-
-    // Transitivity chips (translation-level): ONLY show when multiple transitivity values exist at word level
-    if (hasMultipleWordLevelTransitivities) {
-      core.forEach(tag => {
-        if (isAttribute(tag, ATTRIBUTES.TRANSITIVITY)) {
-          const displayConfig = TAG_DISPLAYS[tag.value_id]
-          if (displayConfig) {
-            chips.push({
-              symbol: displayConfig.display.split(' ')[0], // Use only emoji (🎯, 🌀, ⚖️)
-              title: displayConfig.description,
-              className: 'tag-detailed text-xs px-1 py-0.5 rounded border border-gray-300 text-gray-600 bg-transparent'
-            })
-          }
-        }
-      })
-    }
-
-    // Additional translation-level mapping coverage
-    core.forEach(tag => {
-      const attributeStableId = tag.attribute_stable_id
-      const value = normalizeValue(tag.value_label)
-
-      if (attributeStableId === 'metaattr031') {
-        const articlePatternMap = {
-          'definite-required': {
-            display: 'def. article',
-            description: 'Article pattern: this sense is normally used with a definite article'
-          },
-          'no-article': {
-            display: 'no article',
-            description: 'Article pattern: this sense is normally used without an article'
-          },
-          'flexible-article': {
-            display: 'flex article',
-            description: 'Article pattern: article choice varies by context'
-          },
-          'definite-or-partitive': {
-            display: 'def/partitive',
-            description: 'Article pattern: typically definite or partitive depending on meaning'
-          },
-          'optional-article': {
-            display: 'opt article',
-            description: 'Article pattern: article may be omitted in some standard contexts'
-          },
-          'fixed-no-article': {
-            display: 'fixed no article',
-            description: 'Article pattern: lexicalized fixed construction without article'
-          }
-        }
-        if (articlePatternMap[value]) {
-          addTextChip(articlePatternMap[value].display, articlePatternMap[value].description)
-        }
-      } else if (attributeStableId === 'metaattr059') {
-        const cliticAvailabilityMap = {
-          'core-clitic': {
-            display: 'core clitic',
-            description: 'Clitic availability: clitic usage is core/expected for this entry'
-          },
-          'supports_clitics': {
-            display: 'supports clitics',
-            description: 'Clitic availability: clitic usage is supported'
-          },
-          'no_clitics': {
-            display: 'no clitics',
-            description: 'Clitic availability: clitic forms are not used'
-          },
-          'no-clitics': {
-            display: 'no clitics',
-            description: 'Clitic availability: clitic forms are not used'
-          },
-          'reflexive-clitic': {
-            display: 'refl clitic',
-            description: 'Clitic availability: reflexive clitic usage'
-          },
-          'indirect-clitic': {
-            display: 'indirect clitic',
-            description: 'Clitic availability: indirect-object clitic usage'
-          },
-          'optional-clitic': {
-            display: 'opt clitic',
-            description: 'Clitic availability: clitic usage is optional'
-          },
-          'reciprocal-clitic': {
-            display: 'recip clitic',
-            description: 'Clitic availability: reciprocal clitic usage'
-          }
-        }
-        if (cliticAvailabilityMap[value]) {
-          addTextChip(cliticAvailabilityMap[value].display, cliticAvailabilityMap[value].description)
-        }
-      } else if (attributeStableId === 'metaattr032') {
-        const countableMap = {
-          'countable': {
-            display: 'countable',
-            description: 'Countability: can normally be counted and pluralized'
-          },
-          'uncountable': {
-            display: 'uncountable',
-            description: 'Countability: mass/uncountable usage in this sense'
-          }
-        }
-        if (countableMap[value]) {
-          addTextChip(countableMap[value].display, countableMap[value].description)
-        }
-      } else if (attributeStableId === 'metaattr055') {
-        const governmentMap = {
-          'governs_a': {
-            display: 'gov. a',
-            description: 'Government: this sense typically governs preposition "a"'
-          },
-          'governs_di': {
-            display: 'gov. di',
-            description: 'Government: this sense typically governs preposition "di"'
-          },
-          'governs_da': {
-            display: 'gov. da',
-            description: 'Government: this sense typically governs preposition "da"'
-          },
-          'governs_in': {
-            display: 'gov. in',
-            description: 'Government: this sense typically governs preposition "in"'
-          },
-          'governs_con': {
-            display: 'gov. con',
-            description: 'Government: this sense typically governs preposition "con"'
-          },
-          'governs_su': {
-            display: 'gov. su',
-            description: 'Government: this sense typically governs preposition "su"'
-          },
-          'governs_per': {
-            display: 'gov. per',
-            description: 'Government: this sense typically governs preposition "per"'
-          },
-          'invariable': {
-            display: 'gov. invar',
-            description: 'Government: no single fixed governing preposition'
-          }
-        }
-        if (governmentMap[value]) {
-          addTextChip(governmentMap[value].display, governmentMap[value].description)
-        }
-      } else if (attributeStableId === 'metaattr009') {
-        const gradableMap = {
-          'analytical-gradability': {
-            display: 'analytical',
-            description: 'Gradability: comparative/superlative usually formed analytically (più/meno)'
-          },
-          'full-gradability': {
-            display: 'full grad.',
-            description: 'Gradability: supports full gradation behavior'
-          },
-          'non-gradable': {
-            display: 'non-grad.',
-            description: 'Gradability: not normally gradable in this sense'
-          }
-        }
-        if (gradableMap[value]) {
-          addTextChip(gradableMap[value].display, gradableMap[value].description)
-        }
-      } else if (attributeStableId === 'metaattr050') {
-        const interjectionTypeMap = {
-          'acknowledgment': {
-            display: 'acknowledgment',
-            description: 'Interjection type: acknowledgment response'
-          },
-          'cognitive': {
-            display: 'cognitive',
-            description: 'Interjection type: expresses thought/realization'
-          },
-          'greeting': {
-            display: 'greeting',
-            description: 'Interjection type: greeting/farewell expression'
-          },
-          'exclamation': {
-            display: 'exclamation',
-            description: 'Interjection type: exclamatory reaction'
-          },
-          'cultural-phrase': {
-            display: 'cultural phrase',
-            description: 'Interjection type: fixed cultural expression'
-          }
-        }
-        if (interjectionTypeMap[value]) {
-          addTextChip(interjectionTypeMap[value].display, interjectionTypeMap[value].description)
-        }
-      } else if (attributeStableId === 'metaattr063') {
-        const logicalRelationshipMap = {
-          'addition': {
-            display: 'addition',
-            description: 'Logical relationship: adds information to the previous idea (e.g. and/also)'
-          },
-          'contrast': {
-            display: 'contrast',
-            description: 'Logical relationship: marks contrast or concession between ideas'
-          },
-          'disjunction': {
-            display: 'disjunction',
-            description: 'Logical relationship: presents alternatives or choices'
-          },
-          'causal': {
-            display: 'causal',
-            description: 'Logical relationship: introduces cause/reason'
-          },
-          'conditional': {
-            display: 'conditional',
-            description: 'Logical relationship: introduces a condition'
-          },
-          'temporal': {
-            display: 'temporal',
-            description: 'Logical relationship: links events by time/sequence'
-          },
-          'purpose': {
-            display: 'purpose',
-            description: 'Logical relationship: indicates goal or purpose'
-          },
-          'relative': {
-            display: 'relative (logic)',
-            description: 'Logical relationship: relative-linking function in discourse structure'
-          }
-        }
-        if (logicalRelationshipMap[value]) {
-          addTextChip(logicalRelationshipMap[value].display, logicalRelationshipMap[value].description)
-        }
-      } else if (attributeStableId === 'metaattr021') {
-        const verbTypeMap = {
-          'defective-verb': {
-            display: 'defective',
-            description: 'Verb type: some standard forms are missing from the paradigm'
-          },
-          'impersonal-verb': {
-            display: 'impersonal',
-            description: 'Verb type: used mainly in impersonal constructions, often third person'
-          },
-          'meteorological-verb': {
-            display: 'meteorological',
-            description: 'Verb type: weather/meteorological usage (e.g. rain/snow patterns)'
-          },
-          'modal-verb': {
-            display: 'modal',
-            description: 'Verb type: modal verb, typically combining with an infinitive'
-          },
-          'direct-reflexive': {
-            display: 'direct reflexive',
-            description: 'Verb type: direct reflexive meaning is central for this sense'
-          },
-          'reciprocal': {
-            display: 'reciprocal',
-            description: 'Verb type: reciprocal sense where participants act on each other'
-          },
-          'pronominal-variant': {
-            display: 'pronominal',
-            description: 'Verb type: pronominal variant with fixed clitic/particle behavior'
-          },
-          'transitive-verb': {
-            display: 'transitive',
-            description: 'Verb type: transitive class'
-          },
-          'intransitive-verb': {
-            display: 'intransitive',
-            description: 'Verb type: intransitive class'
-          }
-        }
-        if (verbTypeMap[value]) {
-          addTextChip(verbTypeMap[value].display, verbTypeMap[value].description)
-        }
-      } else if (attributeStableId === 'metaattr013') {
-        const wordRestrictionMap = {
-          'invariable': {
-            display: 'invariable',
-            description: 'Word restriction: this sense behaves as invariable in context'
-          },
-          'plural-only': {
-            display: 'plural only',
-            description: 'Word restriction: used only in plural forms'
-          },
-          'only-plural': {
-            display: 'plural only',
-            description: 'Word restriction: used only in plural forms'
-          },
-          'singular-only': {
-            display: 'singular only',
-            description: 'Word restriction: used only in singular forms'
-          },
-          'third-person-only': {
-            display: '3rd person only',
-            description: 'Word restriction: only third-person forms are used'
-          },
-          'third-singular-only': {
-            display: '3rd singular only',
-            description: 'Word restriction: only third-person singular is used'
-          },
-          'missing-first-second-person': {
-            display: 'no 1st/2nd person',
-            description: 'Word restriction: first and second person forms are not used'
-          },
-          'missing-imperative': {
-            display: 'no imperative',
-            description: 'Word restriction: imperative forms are not used'
-          }
-        }
-        if (wordRestrictionMap[value]) {
-          addTextChip(wordRestrictionMap[value].display, wordRestrictionMap[value].description)
-        }
+        addTextChip(registerLabelMap[value], `${registerLabelMap[value]} register. This sense is specifically marked for that usage context`)
       }
     })
 
@@ -1483,14 +1055,6 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
         rpc_core: t.rpc_core || [],
         rpc_tags: t.rpc_tags || []
       })) || []
-
-  // Word-level transitivity analysis - similar to auxiliaries
-  const wordLevelTransitivities = new Set()
-  translations.forEach(translation => {
-    const transitivities = translation.rpc_core?.filter(tag => isAttribute(tag, ATTRIBUTES.TRANSITIVITY)) || []
-    transitivities.forEach(tag => wordLevelTransitivities.add(tag.value_id))
-  })
-  const hasMultipleWordLevelTransitivities = wordLevelTransitivities.size > 1
 
   const normalizedPronunciationGroups = pronunciationGroups.length > 0
     ? (() => {
@@ -1575,7 +1139,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       ? formatContextHint(translation?.usageNotes || item.note)
       : formatContextHint(item.note)
     const meaningChips = isTranslation
-      ? renderTranslationChips(translation, hasMultipleWordLevelTransitivities)
+      ? renderTranslationChips(translation)
       : []
 
     return (
@@ -1707,7 +1271,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
                   className="rounded-xl border border-white/70 bg-white/75 px-3 py-2 shadow-sm"
                 >
                   <div className="mb-2 flex items-center gap-2 flex-wrap">
-                    <span className="text-lg font-semibold text-gray-900">
+                    <span className="text-sm italic font-medium text-gray-600">
                       {groupLabel}
                     </span>
                     <AudioButton
@@ -1716,12 +1280,12 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
                       audioObjectKey={groupAudio?.object_key || null}
                       audioBucket={groupAudio?.storage_bucket || null}
                       size="chip"
+                      variant="inline-icon"
                       title={
                         groupAudio?.voice_name
                           ? `Play pronunciation variant (${groupAudio.voice_name})`
                           : 'Play pronunciation variant'
                       }
-                      colorClass="bg-emerald-600 hover:bg-emerald-700"
                     />
                   </div>
 
@@ -1753,13 +1317,44 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
           </div>
         )}
 
-        {/* Key Tags - Under Translations */}
-        {orderedBottomTags.length > 0 && (
+        {primaryMetadataTags.length > 0 && (
           <div className="flex gap-1 flex-wrap pt-1">
-            {orderedBottomTags.map((tag, index) => (
+            {primaryMetadataTags.map((tag, index) => (
               <span
-                key={index}
+                key={`primary-${index}`}
                 className={`tag-detailed text-xs px-2 py-1 rounded-full font-semibold ${tag.class}`}
+                data-description={tag.description}
+                onClick={handleTagClick}
+                style={{ cursor: 'pointer' }}
+              >
+                {tag.display}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {lexicalMetadataTags.length > 0 && (
+          <div className="mt-2 flex gap-1 flex-wrap">
+            {lexicalMetadataTags.map((tag, index) => (
+              <span
+                key={`lexical-${index}`}
+                className={`tag-detailed text-xs px-2 py-1 rounded-full font-semibold ${tag.class}`}
+                data-description={tag.description}
+                onClick={handleTagClick}
+                style={{ cursor: 'pointer' }}
+              >
+                {tag.display}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {grammarMetadataTags.length > 0 && (
+          <div className="mt-2 flex gap-1 flex-wrap">
+            {grammarMetadataTags.map((tag, index) => (
+              <span
+                key={`grammar-${index}`}
+                className={`tag-detailed text-[11px] px-2 py-0.5 rounded-full font-medium ${themeOutlineChipClass}`}
                 data-description={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -1338,7 +1338,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             {lexicalMetadataTags.map((tag, index) => (
               <span
                 key={`lexical-${index}`}
-                className={`tag-detailed text-xs px-2 py-1 rounded-full font-semibold ${tag.class}`}
+                className={`tag-detailed text-[11px] px-1.5 py-0.5 rounded-full font-medium ${tag.class}`}
                 data-description={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -986,13 +986,15 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     const chips = []
     const core = Array.isArray(translation.rpc_core) ? translation.rpc_core : []
     const normalizeValue = (value) => String(value || '').trim().toLowerCase()
-    const filledRegisterChipClass = 'inline-block text-[13px] px-2.5 py-1 rounded-full font-semibold leading-none border bg-slate-500 text-white border-slate-500'
-    const addTextChip = (symbol, title) => {
+    const standardRegisterChipClass = 'inline-block text-[13px] px-2.5 py-1 rounded-full font-semibold leading-none border bg-slate-700 text-white border-slate-700'
+    const highRiskRegisterChipClass = 'inline-block text-[13px] px-2.5 py-1 rounded-full font-semibold leading-none border bg-red-900 text-white border-red-900'
+    const isHighRiskRegister = (value) => ['vulgar', 'offensive', 'archaic'].includes(value)
+    const addTextChip = (symbol, title, registerValue = null) => {
       if (!symbol) return
       chips.push({
         symbol,
         title,
-        className: filledRegisterChipClass
+        className: isHighRiskRegister(normalizeValue(registerValue)) ? highRiskRegisterChipClass : standardRegisterChipClass
       })
     }
 
@@ -1003,19 +1005,19 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
           chips.push({
             symbol: TAG_DISPLAYS[VALUES.REGISTER_FORMAL].display,
             title: 'Formal register - use in professional/elevated contexts',
-            className: filledRegisterChipClass
+            className: standardRegisterChipClass
           })
         } else if (isValue(tag, VALUES.REGISTER_CASUAL)) {
           chips.push({
             symbol: TAG_DISPLAYS[VALUES.REGISTER_CASUAL].display,
             title: 'Casual register - informal/everyday speech',
-            className: filledRegisterChipClass
+            className: standardRegisterChipClass
           })
         } else if (isValue(tag, VALUES.REGISTER_MIXED)) {
           chips.push({
             symbol: TAG_DISPLAYS[VALUES.REGISTER_MIXED].display,
             title: 'Mixed register - appropriate in both formal and casual contexts',
-            className: filledRegisterChipClass
+            className: standardRegisterChipClass
           })
         }
         // Note: REGISTER_NEUTRAL is intentionally excluded (not displayed)
@@ -1028,14 +1030,20 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       const value = normalizeValue(tag.value_label)
       const registerLabelMap = {
         'archaic': 'archaic',
+        'figurative': 'figurative',
         'informal': 'informal',
         'literary': 'literary',
+        'offensive': 'offensive',
         'regional': 'regional',
         'vulgar': 'vulgar'
       }
       if (value === 'neutral') return
       if (registerLabelMap[value]) {
-        addTextChip(registerLabelMap[value], `${registerLabelMap[value]} register. This sense is specifically marked for that usage context`)
+        addTextChip(
+          registerLabelMap[value],
+          `${registerLabelMap[value]} register. This sense is specifically marked for that usage context`,
+          value
+        )
       }
     })
 
@@ -1317,12 +1325,23 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
           </div>
         )}
 
-        {primaryMetadataTags.length > 0 && (
+        {(primaryMetadataTags.length > 0 || grammarMetadataTags.length > 0) && (
           <div className="flex gap-1 flex-wrap pt-1">
             {primaryMetadataTags.map((tag, index) => (
               <span
                 key={`primary-${index}`}
                 className={`wordcard-primary-chip inline-block text-[13px] px-2.5 py-1 rounded-full font-semibold leading-none ${tag.class}`}
+                data-description={tag.description}
+                onClick={handleTagClick}
+                style={{ cursor: 'pointer' }}
+              >
+                {tag.display}
+              </span>
+            ))}
+            {grammarMetadataTags.map((tag, index) => (
+              <span
+                key={`grammar-${index}`}
+                className={`wordcard-grammar-chip inline-block text-[12px] px-2.5 py-1 rounded-full font-semibold leading-none ${themeOutlineChipClass}`}
                 data-description={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}
@@ -1339,22 +1358,6 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
               <span
                 key={`lexical-${index}`}
                 className={`wordcard-secondary-chip inline-block text-[10px] px-1.5 py-0.5 rounded-full font-medium leading-none ${tag.class}`}
-                data-description={tag.description}
-                onClick={handleTagClick}
-                style={{ cursor: 'pointer' }}
-              >
-                {tag.display}
-              </span>
-            ))}
-          </div>
-        )}
-
-        {grammarMetadataTags.length > 0 && (
-          <div className="mt-2 flex gap-1 flex-wrap">
-            {grammarMetadataTags.map((tag, index) => (
-              <span
-                key={`grammar-${index}`}
-                className={`wordcard-grammar-chip inline-block text-[12px] px-2.5 py-1 rounded-full font-semibold leading-none ${themeOutlineChipClass}`}
                 data-description={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -1338,7 +1338,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             {lexicalMetadataTags.map((tag, index) => (
               <span
                 key={`lexical-${index}`}
-                className={`tag-detailed text-[11px] px-1.5 py-0.5 rounded-full font-medium ${tag.class}`}
+                className={`tag-detailed text-[9px] px-1 py-px rounded-full font-medium ${tag.class}`}
                 data-description={tag.description}
                 onClick={handleTagClick}
                 style={{ cursor: 'pointer' }}


### PR DESCRIPTION
## Summary\n- expand word-level chip mappings to cover current local tag inventory\n- add frequency rank + frequency tier display support\n- add missing translation-level chip mappings and register variants\n- keep existing hidden rule for register:neutral\n\n## Validation\n- npm run build