### PR TITLE
WordCard: group-level study action + compact sense rows

### DIFF
--- a/components/DictionaryPanel.js
+++ b/components/DictionaryPanel.js
@@ -121,11 +121,18 @@ export default function DictionaryPanel({
   }
 
   // Handle add to deck
-  const handleAddToDeck = (word, translation = null) => {
-    console.log('handleAddToDeck called with:', { word, translation })
+  const handleAddToDeck = (word, translation = null, studyContext = null) => {
+    console.log('handleAddToDeck called with:', { word, translation, studyContext })
     
     // Provide immediate user feedback
-    const item = translation ? `${word.italian} - ${translation.translation}` : word.italian
+    let item = word.italian
+    if (studyContext?.mode === 'pronunciation-group') {
+      const groupLabel = studyContext.groupLabel || 'pronunciation group'
+      const meaningCount = Array.isArray(studyContext.translations) ? studyContext.translations.length : 0
+      item = `${word.italian} - ${groupLabel} (${meaningCount} meaning${meaningCount === 1 ? '' : 's'})`
+    } else if (translation) {
+      item = `${word.italian} - ${translation.translation}`
+    }
     
     // Show visual feedback (you can replace this with a proper toast/notification system)
     try {
@@ -136,7 +143,11 @@ export default function DictionaryPanel({
     }
     
     // TODO: Implement actual deck addition logic
-    console.log('Adding to deck:', { word: word.italian, translation: translation?.translation })
+    console.log('Adding to deck:', {
+      word: word.italian,
+      translation: translation?.translation,
+      studyContext
+    })
   }
 
   // Resize functionality

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -2,7 +2,7 @@
 
 // components/WordCard.js
 // Updated for Story 10: Multiple Translations Display
-// Shows top 2+ translations with individual "Study This Translation" buttons
+// Uses pronunciation-group-level study action and compact sense rows
 
 import { useState, useEffect } from 'react'
 import AudioButton from './AudioButton'
@@ -1152,17 +1152,17 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
 
     return (
       <div key={item.key || `${groupKey}-${index}`}>
-        <div className="flex items-start gap-2 py-1.5 min-h-[32px]">
-          <div className="w-5 flex-shrink-0 pt-0.5 text-sm font-bold text-gray-500">
+        <div className="flex items-start gap-1.5 py-0.5 min-h-[24px]">
+          <div className="w-5 flex-shrink-0 pt-0.5 text-sm font-bold text-gray-500 leading-tight">
             {index}.
           </div>
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2 flex-wrap">
-              <span className={`text-base ${isTranslation ? 'text-gray-900 font-medium' : 'text-gray-700'}`}>
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <span className={`text-base leading-tight ${isTranslation ? 'text-gray-900 font-medium' : 'text-gray-700'}`}>
                 {displayText}
               </span>
               {meaningChips.length > 0 && (
-                <span className="flex items-center gap-1 flex-wrap">
+                <span className="flex items-center gap-0.5 flex-wrap leading-tight">
                   {meaningChips.map((chip, chipIndex) => (
                     <span
                       key={`meaning-chip-${groupKey}-${index}-${chipIndex}`}
@@ -1178,22 +1178,11 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
               )}
             </div>
             {usageText && (
-              <div className="mt-0.5 text-xs italic text-gray-500">
+              <div className="mt-0 text-[11px] leading-tight italic text-gray-500">
                 {usageText}
               </div>
             )}
           </div>
-          {isTranslation && (
-            <div className="flex-shrink-0 pt-0.5">
-              <button
-                onClick={() => onAddToDeck && onAddToDeck(word, translation)}
-                className="bg-emerald-600 text-white w-7 h-7 rounded flex items-center justify-center text-sm font-bold hover:bg-emerald-700 transition-colors cursor-pointer"
-                title={`Study: ${translation.translation}`}
-              >
-                +
-              </button>
-            </div>
-          )}
         </div>
       </div>
     )
@@ -1265,6 +1254,18 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             {normalizedPronunciationGroups.map((group) => {
               const groupLabel = formatPronunciationGroupLabel(group)
               const groupAudio = group?.primary_audio || null
+              const groupTranslations = []
+              const seenGroupTranslationIds = new Set()
+              group.meaningItems.forEach((item) => {
+                if (item.kind !== 'translation' || !item.translation) return
+                const dedupeKey = item.translation.id || item.translation.translation
+                if (seenGroupTranslationIds.has(dedupeKey)) return
+                seenGroupTranslationIds.add(dedupeKey)
+                groupTranslations.push(item.translation)
+              })
+              const groupTranslationIds = groupTranslations
+                .map((translation) => translation?.id)
+                .filter(Boolean)
               const visibleItems = group.meaningItems.slice(0, maxVisibleMeaningsPerGroup)
               const additionalItems = group.meaningItems.slice(maxVisibleMeaningsPerGroup)
               const isExpanded = !!expandedMeaningGroups[group.key]
@@ -1278,7 +1279,7 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
                   key={group.key}
                   className="rounded-xl border border-white/70 bg-white/75 px-3 py-2 shadow-sm"
                 >
-                  <div className="mb-2 flex items-center gap-2 flex-wrap">
+                  <div className="mb-2 flex items-center gap-2">
                     <span className="text-base italic font-medium text-gray-600">
                       {groupLabel}
                     </span>
@@ -1295,6 +1296,23 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
                           : 'Play pronunciation variant'
                       }
                     />
+                    {onAddToDeck && groupTranslations.length > 0 && (
+                      <button
+                        onClick={() =>
+                          onAddToDeck(word, null, {
+                            mode: 'pronunciation-group',
+                            groupId: group.id || group.key,
+                            groupLabel,
+                            translations: groupTranslations,
+                            translationIds: groupTranslationIds
+                          })
+                        }
+                        className="ml-auto bg-emerald-600 text-white w-7 h-7 rounded flex items-center justify-center text-sm font-bold hover:bg-emerald-700 transition-colors cursor-pointer"
+                        title={`Study pronunciation group: ${groupLabel} (${groupTranslations.length} meaning${groupTranslations.length === 1 ? '' : 's'})`}
+                      >
+                        +
+                      </button>
+                    )}
                   </div>
 
                   <div className="space-y-1">

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -1307,10 +1307,10 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
                             translationIds: groupTranslationIds
                           })
                         }
-                        className="ml-auto bg-emerald-600 text-white w-7 h-7 rounded flex items-center justify-center text-sm font-bold hover:bg-emerald-700 transition-colors cursor-pointer"
+                        className="ml-auto w-6 h-6 inline-flex items-center justify-center text-emerald-700 hover:text-emerald-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 rounded-sm transition-colors cursor-pointer"
                         title={`Study pronunciation group: ${groupLabel} (${groupTranslations.length} meaning${groupTranslations.length === 1 ? '' : 's'})`}
                       >
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                           <path d="M12 5V19" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
                           <path d="M5 12H19" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
                         </svg>

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -1311,8 +1311,8 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
                         title={`Study pronunciation group: ${groupLabel} (${groupTranslations.length} meaning${groupTranslations.length === 1 ? '' : 's'})`}
                       >
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                          <path d="M12 5V19" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
-                          <path d="M5 12H19" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+                          <path d="M12 5V19" stroke="currentColor" strokeWidth="3.6" strokeLinecap="round" />
+                          <path d="M5 12H19" stroke="currentColor" strokeWidth="3.6" strokeLinecap="round" />
                         </svg>
                       </button>
                     )}

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -986,8 +986,8 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     const chips = []
     const core = Array.isArray(translation.rpc_core) ? translation.rpc_core : []
     const normalizeValue = (value) => String(value || '').trim().toLowerCase()
-    const standardRegisterChipClass = 'inline-block text-[13px] px-2.5 py-1 rounded-full font-semibold leading-none border bg-slate-700 text-white border-slate-700'
-    const highRiskRegisterChipClass = 'inline-block text-[13px] px-2.5 py-1 rounded-full font-semibold leading-none border bg-red-900 text-white border-red-900'
+    const standardRegisterChipClass = 'inline-block text-[12px] px-2 py-0.5 rounded-full font-semibold leading-none border bg-slate-700 text-white border-slate-700'
+    const highRiskRegisterChipClass = 'inline-block text-[12px] px-2 py-0.5 rounded-full font-semibold leading-none border bg-red-900 text-white border-red-900'
     const isHighRiskRegister = (value) => ['vulgar', 'offensive', 'archaic'].includes(value)
     const addTextChip = (symbol, title, registerValue = null) => {
       if (!symbol) return
@@ -1310,7 +1310,10 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
                         className="ml-auto bg-emerald-600 text-white w-7 h-7 rounded flex items-center justify-center text-sm font-bold hover:bg-emerald-700 transition-colors cursor-pointer"
                         title={`Study pronunciation group: ${groupLabel} (${groupTranslations.length} meaning${groupTranslations.length === 1 ? '' : 's'})`}
                       >
-                        +
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                          <path d="M12 5V19" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+                          <path d="M5 12H19" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+                        </svg>
                       </button>
                     )}
                   </div>


### PR DESCRIPTION
## Summary\n- move study  from individual sense rows to pronunciation-group IPA rows\n- send whole-group study context payload via \n- compact sense row spacing (padding/line-height/gaps)\n\n## Details\n- add one  button per pronunciation group, right-aligned on IPA row\n- payload now includes \n- extend  to accept optional  and show group-level feedback\n- remove per-sense  buttons\n\n## Validation\n- 
> misti@0.1.0 build
> next build

  ▲ Next.js 14.2.32
  - Environments: .env.local

   Creating an optimized production build ...
 ✓ Compiled successfully
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/4) ...
   Generating static pages (1/4) 
   Generating static pages (2/4) 
   Generating static pages (3/4) 
 ✓ Generating static pages (4/4)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                              Size     First Load JS
┌ ○ /                                    138 B          87.3 kB
└ ○ /_not-found                          873 B            88 kB
+ First Load JS shared by all            87.2 kB
  ├ chunks/117-5084c01a079b682e.js       31.6 kB
  ├ chunks/fd9d1056-42a1c2df9c4a85a8.js  53.6 kB
  └ other shared chunks (total)          1.92 kB


○  (Static)  prerendered as static content passes