### PR TITLE
WordCard: show conjugation type in POS chip

### DIFF
--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -916,11 +916,17 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
   const genderTag = processedTags.essential.find(tag =>
     tag.display === '♂' || tag.display === '♀' || tag.display === '⚥'
   )
+  const irregularTag = processedTags.essential.find(tag =>
+    typeof tag?.display === 'string' && tag.display.includes('IRREG')
+  )
 
   // All other tags go under translations
   const bottomTags = [
     ...processedTags.essential.filter(tag =>
-      tag.display !== '♂' && tag.display !== '♀' && tag.display !== '⚥'
+      tag.display !== '♂' &&
+      tag.display !== '♀' &&
+      tag.display !== '⚥' &&
+      !(typeof tag?.display === 'string' && tag.display.includes('IRREG'))
     ),
     ...processedTags.detailed
   ]
@@ -1002,13 +1008,53 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     const standardRegisterChipClass = 'inline-block text-[12px] px-2 py-0.5 rounded-full font-semibold leading-none border bg-slate-700 text-white border-slate-700'
     const highRiskRegisterChipClass = 'inline-block text-[12px] px-2 py-0.5 rounded-full font-semibold leading-none border bg-red-900 text-white border-red-900'
     const isHighRiskRegister = (value) => ['vulgar', 'offensive', 'archaic'].includes(value)
-    const addTextChip = (symbol, title, registerValue = null) => {
+    const addTextChip = (symbol, title, registerValue = null, classNameOverride = null) => {
       if (!symbol) return
       chips.push({
         symbol,
         title,
-        className: isHighRiskRegister(normalizeValue(registerValue)) ? highRiskRegisterChipClass : standardRegisterChipClass
+        className: classNameOverride || (isHighRiskRegister(normalizeValue(registerValue)) ? highRiskRegisterChipClass : standardRegisterChipClass)
       })
+    }
+    const neutralSenseChipClass = 'inline-block text-[12px] px-2 py-0.5 rounded-full font-semibold leading-none border bg-slate-700 text-white border-slate-700'
+
+    // Conditional auxiliary/transitivity chips: show only when they disambiguate across this lemma.
+    const translationRows = Array.isArray(translations) ? translations : []
+    const uniqueAuxiliaries = new Set()
+    const uniqueTransitivities = new Set()
+    translationRows.forEach((row) => {
+      const rowCore = Array.isArray(row?.rpc_core) ? row.rpc_core : []
+      rowCore.forEach((tag) => {
+        if (isAttribute(tag, ATTRIBUTES.AUXILIARY_VERB)) {
+          uniqueAuxiliaries.add(normalizeValue(tag.value_label))
+        }
+        if (isAttribute(tag, ATTRIBUTES.TRANSITIVITY)) {
+          uniqueTransitivities.add(tag.value_id || normalizeValue(tag.value_label))
+        }
+      })
+    })
+
+    if (uniqueAuxiliaries.size > 1) {
+      const auxTag = core.find((tag) => isAttribute(tag, ATTRIBUTES.AUXILIARY_VERB))
+      const auxValue = normalizeValue(auxTag?.value_label)
+      if (auxValue === 'avere') {
+        addTextChip('av.', 'Auxiliary: avere', null, neutralSenseChipClass)
+      } else if (auxValue === 'essere') {
+        addTextChip('ess.', 'Auxiliary: essere', null, neutralSenseChipClass)
+      }
+    }
+
+    if (uniqueTransitivities.size > 1) {
+      const transitivityTag = core.find((tag) => isAttribute(tag, ATTRIBUTES.TRANSITIVITY))
+      if (transitivityTag) {
+        if (isValue(transitivityTag, VALUES.TRANSITIVITY_TRANSITIVE)) {
+          addTextChip('trans', 'Transitivity: transitive', null, neutralSenseChipClass)
+        } else if (isValue(transitivityTag, VALUES.TRANSITIVITY_INTRANSITIVE)) {
+          addTextChip('intrans', 'Transitivity: intransitive', null, neutralSenseChipClass)
+        } else if (isValue(transitivityTag, VALUES.TRANSITIVITY_AMBITRANSITIVE)) {
+          addTextChip('ambi', 'Transitivity: ambitransitive', null, neutralSenseChipClass)
+        }
+      }
     }
 
     // Register chips (translation-level, emoji-only display)
@@ -1256,6 +1302,18 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
             ) : (
               <span className={`px-3 py-1 rounded-full text-sm font-semibold border ${colors.tag}`}>
                 {wordTypeLabel}
+              </span>
+            )}
+
+            {/* Irregularity chip in header, after POS */}
+            {irregularTag && (
+              <span
+                className={`tag-essential text-xs px-2 py-1 rounded-full font-semibold ${irregularTag.class}`}
+                data-description={irregularTag.description}
+                onClick={handleTagClick}
+                style={{ cursor: 'pointer' }}
+              >
+                {irregularTag.display}
               </span>
             )}
           </div>

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -875,7 +875,24 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
     : []
   const maxVisibleMeaningsPerGroup = 2
 
-  const wordTypeLabel = word.word_type
+  const verbConjugationLabel = String(word.word_type || '').toUpperCase() === 'VERB'
+    ? (() => {
+        const coreTags = Array.isArray(word.word_core_tags) ? word.word_core_tags : []
+        const conjugationTag = coreTags.find((tag) => isAttribute(tag, ATTRIBUTES.CONJUGATION_TYPE))
+        const conjugationValue = String(conjugationTag?.value_label || '').trim().toLowerCase()
+        const conjugationMap = {
+          'are': 'ARE',
+          'ere': 'ERE',
+          'ire': 'IRE',
+          'ire-isc': 'IRE-ISC'
+        }
+        return conjugationMap[conjugationValue] || ''
+      })()
+    : ''
+  const wordTypeLabel =
+    String(word.word_type || '').toUpperCase() === 'VERB' && verbConjugationLabel
+      ? `VERB - ${verbConjugationLabel}`
+      : word.word_type
 
   // Convert filled tag classes to outlined style for less visual weight
   const outlinedClass = (cls) => {

--- a/components/WordCard.js
+++ b/components/WordCard.js
@@ -974,10 +974,6 @@ export default function WordCard({ word, onAddToDeck, className = '' }) {
       tag.tag === 'form-invariable' ||
       tag.tag === 'reflexive' ||
       tag.tag === 'reflexive-verb' ||
-      tag.tag === 'are-conjugation' ||
-      tag.tag === 'ere-conjugation' ||
-      tag.tag === 'ire-conjugation' ||
-      tag.tag === 'ire-isc-conjugation' ||
       tag.tag.startsWith('plural-formation-') ||
       tag.tag.startsWith('noun-type-') ||
       tag.tag.startsWith('determiner-type-') ||


### PR DESCRIPTION
## Summary
- backport POS+conjugation label logic from rpc-model-refactor-cutover into wordcard-cleanup
- keep all newer wordcard-cleanup behavior unchanged

## Behavior
- verbs with conjugation tag now show:
  - VERB - ARE
  - VERB - ERE
  - VERB - IRE
  - VERB - IRE-ISC
- missing conjugation metadata falls back to VERB

## Validation
- npm run build passes
